### PR TITLE
CIF-1211 - add sample /etc/map config for publish instance

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/config.publish/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/config.publish/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.xml
@@ -2,4 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:OsgiConfig"
     resource.resolver.mapping="[/content/venia/&lt;/,/:/]"
+    resource.resolver.map.location="/etc/map.publish"
 />

--- a/ui.content/src/main/content/META-INF/vault/filter.xml
+++ b/ui.content/src/main/content/META-INF/vault/filter.xml
@@ -4,4 +4,5 @@
     <filter root="/content/venia" mode="merge"/>
     <filter root="/content/dam/venia" mode="merge"/>
     <filter root="/content/experience-fragments/venia" mode="merge"/>
+    <filter root="/etc/map.publish" mode="merge"/>
 </workspaceFilter>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/.content.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"
+    hidden="true"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/category-page-reverse/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/category-page-reverse/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/category-page\\.(\\d+)\\.html/(.+)"
+    sling:match="$1/$2/$4.$3.html"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/category-page/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/category-page/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/$1/$2/products/category-page.$4.html/$3"
+    sling:match="content/venia/([a-z]{2})/([a-z]{2})/(.+?)\\.(\\d+)\\.html"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/product-page-reverse/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/product-page-reverse/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/([a-z]{2})/([a-z]{2})/products/product-page\\.(.+)"
+    sling:match="$1/$2/$3"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/product-page/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/product-page/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Mapping"
+    sling:internalRedirect="/content/venia/$1/$2/products/product-page.$3.html"
+    sling:match="content/venia/([a-z]{2})/([a-z]{2})/([^\\.]+?).html"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds a sample resource mapping config for /etc/map for a publish instance to work in combination with the URLProvider for PDP & PLPs.

The config has to be adapted to the environment the project is deployed on later. The folder name `hostname.adobeaemcloud.com` must match the hostname of the publish instance.

## Related Issue

CIF-1211

## Motivation and Context

Demonstrate the usage of the URLProvider and have nice looking URLs.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.