### PR TITLE
CIF-1490 - Add maven classifiers to Venia content packages

### DIFF
--- a/.circleci/ci/deploy-venia.js
+++ b/.circleci/ci/deploy-venia.js
@@ -18,8 +18,6 @@ const ci = new (require("./ci.js"))();
 
 ci.context();
 
-ci.stage("Build and install Venia");
-ci.sh("mvn clean install");
 const releaseVersion = ci.sh(`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`, true).toString().trim();
 const releaseArtifact = ci.sh(`mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout`, true).toString().trim();
 
@@ -31,10 +29,18 @@ ci.sh(
 ci.sh("mv tmp/**/ghr ./ghr");
 ci.sh("chmod +x ghr");
 
+ci.sh("mkdir -p artifacts"); // target folder for all the build artifacts
+
+let profiles = ['cloud', 'classic'];
+profiles.forEach(profile => {
+	ci.stage(`Build and install Venia '${profile}'`);
+	ci.sh(`mvn clean install -P${profile}`);
+	ci.sh(`cp all/target/${releaseArtifact}.all-${releaseVersion}-${profile}.zip artifacts`);
+})
+
 ci.stage("Deploy Venia Sample Project to GitHub");
-const allPackagePath = `all/target/${releaseArtifact}.all-${releaseVersion}.zip`;
 ci.sh(`./ghr -t ${ci.env("GITHUB_TOKEN")} \
     -u ${ci.env("CIRCLE_PROJECT_USERNAME")} \
     -r ${ci.env("CIRCLE_PROJECT_REPONAME")} \
     -c ${ci.env("CIRCLE_SHA1")} \
-    -replace ${ci.env("CIRCLE_TAG")} ${allPackagePath}`);
+    -replace ${ci.env("CIRCLE_TAG")} artifacts/`);

--- a/.circleci/ci/deploy-venia.js
+++ b/.circleci/ci/deploy-venia.js
@@ -33,9 +33,9 @@ ci.sh("mkdir -p artifacts"); // target folder for all the build artifacts
 
 let profiles = ['cloud', 'classic'];
 profiles.forEach(profile => {
-	ci.stage(`Build and install Venia '${profile}'`);
-	ci.sh(`mvn clean install -P${profile}`);
-	ci.sh(`cp all/target/${releaseArtifact}.all-${releaseVersion}-${profile}.zip artifacts`);
+    ci.stage(`Build and install Venia '${profile}'`);
+    ci.sh(`mvn clean install -P${profile}`);
+    ci.sh(`cp all/target/${releaseArtifact}.all-${releaseVersion}-${profile}.zip artifacts`);
 })
 
 ci.stage("Deploy Venia Sample Project to GitHub");

--- a/all/pom.xml
+++ b/all/pom.xml
@@ -50,16 +50,19 @@
                 <extensions>true</extensions>
                 <configuration>
                     <group>com.venia</group>
+                    <classifier>${project.classifier}</classifier>
                     <embeddeds>
                         <embedded>
                             <groupId>com.venia</groupId>
                             <artifactId>venia.ui.apps</artifactId>
+                            <classifier>${project.classifier}</classifier>
                             <type>zip</type>
                             <target>/apps/venia-packages/application/install</target>
                         </embedded>
                         <embedded>
                             <groupId>com.venia</groupId>
                             <artifactId>venia.ui.content</artifactId>
+                            <classifier>${project.classifier}</classifier>
                             <type>zip</type>
                             <target>/apps/venia-packages/content/install</target>
                         </embedded>
@@ -207,12 +210,14 @@
             <groupId>com.venia</groupId>
             <artifactId>venia.ui.apps</artifactId>
             <version>${project.version}</version>
+            <classifier>${project.classifier}</classifier>
             <type>zip</type>
         </dependency>
         <dependency>
             <groupId>com.venia</groupId>
             <artifactId>venia.ui.content</artifactId>
             <version>${project.version}</version>
+            <classifier>${project.classifier}</classifier>
             <type>zip</type>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -267,10 +267,59 @@ Bundle-DocURL:
                 <plugin>
                     <groupId>org.apache.jackrabbit</groupId>
                     <artifactId>filevault-package-maven-plugin</artifactId>
-                    <version>1.0.3</version>
+                    <version>1.1.4</version>
                     <configuration>
                         <filterSource>src/main/content/META-INF/vault/filter.xml</filterSource>
                     </configuration>
+                    <executions>
+                        <!-- Disables the long output of the analyze goal -->
+                        <execution>
+                            <id>default-analyze-classes</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>analyze-classes</goal>
+                            </goals>
+                            <configuration>
+                                <showImportPackageReport>false</showImportPackageReport>
+                            </configuration>
+                        </execution>
+                        <!--
+                            With the introduction of classifiers in version 1.1.4 of the filevault-package-maven-plugin,
+                            some goals automatically add the classifier to the vault-work directory and/or the package file,
+                            but some others don't or somehow dot not properly handle the work directory parameter.
+                            These 3 configs fix these issues but the plugin still displays some warnings that can be ignored.
+                        -->
+                        <execution>
+                            <id>default-package</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>package</goal>
+                            </goals>
+                            <configuration>
+                                <workDirectory>${project.build.directory}/vault-work-${project.classifier}</workDirectory>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-validate-package</id>
+                            <phase>validate-package</phase>
+                            <goals>
+                                <goal>verify</goal>
+                            </goals>
+                            <configuration>
+                                <packageFile>${project.artifact.file}</packageFile>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>default-validate-files</id>
+                            <phase>validate-files</phase>
+                            <goals>
+                                <goal>process-classes</goal>
+                            </goals>
+                            <configuration>
+                                <workDirectory>${project.build.directory}/vault-work-${project.classifier}</workDirectory>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <!-- Content Package Plugin -->
                 <plugin>

--- a/ui.apps.structure/pom.xml
+++ b/ui.apps.structure/pom.xml
@@ -50,6 +50,29 @@
 
                     </filters>
                 </configuration>
+                <!-- These two configs disable the use of classifiers added by default in the parent POM -->
+                <executions>
+                    <execution>
+                        <id>default-package</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>package</goal>
+                        </goals>
+                        <configuration>
+                            <workDirectory>${project.build.directory}/vault-work</workDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>default-validate-files</id>
+                        <phase>validate-files</phase>
+                        <goals>
+                            <goal>process-classes</goal>
+                        </goals>
+                        <configuration>
+                            <workDirectory>${project.build.directory}/vault-work</workDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/ui.apps/pom.xml
+++ b/ui.apps/pom.xml
@@ -51,6 +51,7 @@
                 <configuration>
                     <group>com.venia</group>
                     <name>venia.ui.apps</name>
+                    <classifier>${project.classifier}</classifier>
                     <packageType>application</packageType>
                     <accessControlHandling>merge</accessControlHandling>
                     <properties>

--- a/ui.content/pom.xml
+++ b/ui.content/pom.xml
@@ -81,6 +81,7 @@
                 <configuration>
                     <group>com.venia</group>
                     <name>venia.ui.content</name>
+                    <classifier>${project.classifier}</classifier>
                     <packageType>content</packageType>
                     <accessControlHandling>merge</accessControlHandling>
                     <properties>
@@ -91,6 +92,7 @@
                             <groupId>com.venia</groupId>
                             <artifactId>venia.ui.apps</artifactId>
                             <version>${project.version}</version>
+                            <classifier>${project.classifier}</classifier>
                         </dependency>
                     </dependencies>
                     <excludes>
@@ -155,6 +157,7 @@
             <groupId>com.venia</groupId>
             <artifactId>venia.ui.apps</artifactId>
             <version>${project.version}</version>
+            <classifier>${project.classifier}</classifier>
             <type>zip</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR adds Maven classifiers to all the content packages that will have `cloud` or `classic` specific content. This ensures that, for example, the `all` module creates a different artefact for each profile:
- `venia.all-1.0.0-SNAPSHOT-cloud.zip` for the cloud profile (or when not specifying any profile)
- `venia.all-1.0.0-SNAPSHOT-classic.zip` for the classic profile

This is mainly useful to ensure that the `all` package doesn't include a content package built for a different profile.

I also fixed the deploy script so that we will release both `all` content packages (that is, `-cloud` and `-classic`) when doing a release.

## How Has This Been Tested?

Locally tested with both profiles.

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.