### PR TITLE
trivial - Remove CIF React clientlib from clientlib-cif

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/clientlibs/clientlib-cif/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/clientlibs/clientlib-cif/.content.xml
@@ -5,4 +5,4 @@
     cssProcessor="[default:none,min:none]"
     jsProcessor="[default:none,min:none]"
     categories="[venia.cif]" 
-    embed="[core.cif.components.product.v1,core.cif.components.productcarousel.v1,core.cif.components.productlist.v1,core.cif.components.productteaser.v1,core.cif.components.searchbar.v1,core.cif.components.header.v1,core.cif.components.navigation.v1,core.cif.components.react]" />
+    embed="[core.cif.components.product.v1,core.cif.components.productcarousel.v1,core.cif.components.productlist.v1,core.cif.components.productteaser.v1,core.cif.components.searchbar.v1,core.cif.components.header.v1,core.cif.components.navigation.v1]" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* The CIF React components are added to Venia via the `ui.frontend` module and the `clientlib-base`. The dependency specified in `clientlib-cif` is a duplication and needs to be removed.

## How Has This Been Tested?

* Manually tested

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.