### PR TITLE
releng - Support builds with snapshot dependencies

### DIFF
--- a/.circleci/ci/deploy-venia.js
+++ b/.circleci/ci/deploy-venia.js
@@ -18,6 +18,11 @@ const ci = new (require("./ci.js"))();
 
 ci.context();
 
+if (ci.env("DEPENDENCIES") !== "production") {
+    console.log("Skip deployment, since non-production dependencies are required.");
+    return;
+}
+
 const releaseVersion = ci.sh(`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`, true).toString().trim();
 const releaseArtifact = ci.sh(`mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout`, true).toString().trim();
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,7 @@ jobs:
       - checkout
       - restore_cache:
           keys: 
+            - maven-repo-v1-{{ checksum "pom.xml" }}-{{ .Environment.DEPENDENCIES }}
             - maven-repo-v1-{{ checksum "pom.xml" }}
             - maven-repo-v1-
       - run:
@@ -52,7 +53,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-          key: maven-repo-v1-{{ checksum "pom.xml" }}
+          key: maven-repo-v1-{{ checksum "pom.xml" }}-{{ .Environment.DEPENDENCIES }}
       - store_test_results:
           path: core/target/surefire-reports
       - store_artifacts:
@@ -66,6 +67,7 @@ jobs:
       - checkout
       - restore_cache:
           keys: 
+            - maven-repo-v1-{{ checksum "pom.xml" }}-{{ .Environment.DEPENDENCIES }}
             - maven-repo-v1-{{ checksum "pom.xml" }}
             - maven-repo-v1-
       - run:
@@ -85,7 +87,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.m2
-          key: maven-repo-v1-{{ checksum "pom.xml" }}
+          key: maven-repo-v1-{{ checksum "pom.xml" }}-{{ .Environment.DEPENDENCIES }}
 
   deploy-sample:
     executor: cif_executor
@@ -99,6 +101,7 @@ jobs:
       - checkout
       - restore_cache:
           keys:
+            - maven-repo-v1-{{ checksum "pom.xml" }}-{{ .Environment.DEPENDENCIES }}
             - maven-repo-v1-{{ checksum "pom.xml" }}
             - maven-repo-v1-
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,24 @@ executors:
   cif_executor:
     docker:
       - image: circleci/openjdk:11-jdk-node
+    environment:
+      # either snapshot or production
+      DEPENDENCIES: snapshot
+
+commands:
+  install-dependencies:
+    description: "Installs all required snapshot dependencies"
+    steps:
+      - run:
+          command: |
+            if [[ "$DEPENDENCIES" == "snapshot" ]]; then
+              git clone --depth 1 https://github.com/adobe/aem-core-cif-components.git
+              cd aem-core-cif-components
+              mvn -B clean install
+              cd react-components
+              npm link
+            fi
+          working_directory: ./dependencies
 
 jobs:
   build:
@@ -20,12 +38,17 @@ jobs:
       - run:
           name: Update permissions
           command: sudo chown -R circleci /usr/local/lib/node_modules
+      - install-dependencies
       - run:
           name: Build
           command: |
             java -version
             mvn -v
-            mvn -B clean install
+            if [[ "$DEPENDENCIES" == "snapshot" ]]; then
+              mvn -B clean install -Pcloud,fedDev
+            else
+              mvn -B clean install
+            fi
       - save_cache:
           paths:
             - ~/.m2
@@ -48,12 +71,17 @@ jobs:
       - run:
           name: Update permissions
           command: sudo chown -R circleci /usr/local/lib/node_modules
+      - install-dependencies
       - run:
           name: Build
           command: |
             java -version
             mvn -v
-            mvn -B clean install -Pclassic
+            if [[ "$DEPENDENCIES" == "snapshot" ]]; then
+              mvn -B clean install -Pclassic,fedDev
+            else
+              mvn -B clean install -Pclassic
+            fi
       - save_cache:
           paths:
             - ~/.m2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Open for discussion

* If the repo is in a state that would require snapshot dependencies, change the `DEPENDENCIES` environment variable in the CircleCI config to `snapshot`. It will then checkout and build the CIF components repo.
* After a release of the dependencies, all dependencies should be updated an the `DEPENDENCIES` environment variable should be set back to `production`.
* Deployment/release is blocked as long as there are snapshot dependencies.