### PR TITLE
CIF-1591 - Missing portal container breaks all React components

### DIFF
--- a/ui.frontend/src/main/components/App/App.js
+++ b/ui.frontend/src/main/components/App/App.js
@@ -47,7 +47,9 @@ const App = () => {
                     <Portal selector={mountingPoints.cartTrigger}>
                         <CartTrigger />
                     </Portal>
-                    <Cart />
+                    <Portal selector={mountingPoints.minicart}>
+                        <Cart />
+                    </Portal>
                     <Portal selector={mountingPoints.authBarContainer}>
                         <AuthBar />
                     </Portal>
@@ -66,12 +68,13 @@ const App = () => {
 };
 
 window.onload = () => {
-    const mountPoint = document.getElementById('minicart');
+    const root = document.createElement('div');
+    document.body.appendChild(root);
     ReactDOM.render(
         <Router>
             <App />
         </Router>,
-        mountPoint
+        root
     );
 };
 

--- a/ui.frontend/src/main/components/App/config.js
+++ b/ui.frontend/src/main/components/App/config.js
@@ -16,7 +16,8 @@ export default {
         accountContainer: '.header__accountTrigger #miniaccount',
         addressBookContainer: '#addressbook',
         authBarContainer: 'aside.navigation__root #miniaccount',
-        cartTrigger: '.header__cartTrigger'
+        cartTrigger: '.header__cartTrigger',
+        minicart: '#minicart'
     },
     pagePaths: {
         addressBook: '/content/venia/us/en/my-account/address-book.html'


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Moved `Cart` component into a `Portal` component, to make it resilient against a missing `#minicart` container.
* I tested that removing the DOM containers of any of the components does not break the other ones.

## How Has This Been Tested?

* Manual tested

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.