### PR TITLE
CIF-1592 - Update filter mode for templates to fix upgrades

### DIFF
--- a/ui.content/src/main/content/filter-templates/filter-classic.xml
+++ b/ui.content/src/main/content/filter-templates/filter-classic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
-    <filter root="/conf/venia" mode="merge"/>
+    <filter root="/conf/venia" mode="update"/>
     <filter root="/content/venia" mode="merge"/>
     <filter root="/content/dam/venia" mode="merge"/>
     <filter root="/content/experience-fragments/venia" mode="merge"/>

--- a/ui.content/src/main/content/filter-templates/filter-cloud.xml
+++ b/ui.content/src/main/content/filter-templates/filter-cloud.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <workspaceFilter version="1.0">
-    <filter root="/conf/venia" mode="merge"/>
+    <filter root="/conf/venia" mode="update"/>
     <filter root="/content/venia" mode="merge"/>
     <filter root="/content/dam/venia" mode="merge"/>
     <filter root="/content/experience-fragments/venia" mode="merge"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Updated filter mode of templates to `update` to properly add new nodes on upgrade. 
* This in particular fixes an issue where the `miniaccount` node was not correctly added to the `header` in templates.

## How Has This Been Tested?

* Manually tested.
* Install an older version of Venia that for example doesn't have the `miniaccount` nodes yet (e.g. https://github.com/adobe/aem-cif-guides-venia/tree/de00a556cfcd1d41a5a3d1bdffd2ab96ed398941).
* Install the latest Venia release and see that some `miniaccount` are not added.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.