### PR TITLE
CIF-1635: Remove @magento/peregrine dependency

### DIFF
--- a/ui.frontend/package-lock.json
+++ b/ui.frontend/package-lock.json
@@ -3400,11 +3400,6 @@
         "to-fast-properties": "^2.0.0"
       }
     },
-    "@magento/peregrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@magento/peregrine/-/peregrine-3.0.0.tgz",
-      "integrity": "sha512-PQWhK26X0IcFfx+1Y0BjyYS0ZfIKqNVoDs09zzX87YCijxCLFXyRmIDCaBXXB3hjLnkOXhmQh5nJefeWfSUvLw=="
-    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",

--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -63,7 +63,6 @@
   },
   "dependencies": {
     "@adobe/aem-core-cif-react-components": "^1.4.0",
-    "@magento/peregrine": "^3.0.0",
     "i18next": "^19.5.3",
     "i18next-browser-languagedetector": "^5.0.0",
     "i18next-xhr-backend": "^3.2.2",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove unnecessary @magento/peregrine dependency

## Related Issue

CIF-1635

## Motivation and Context

@magento/peregrine was removed from React Core CIF https://github.com/adobe/aem-core-cif-components/pull/418

## How Has This Been Tested?

Manual UI test

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.