### PR TITLE
CIF-1673 - add commerce teaser styles & corresponding policies

### DIFF
--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/policies/.content.xml
@@ -416,6 +416,38 @@
                         <jcr:content jcr:primaryType="nt:unstructured"/>
                     </default>
                 </featuredcategorylist>
+                <teaser jcr:primaryType="nt:unstructured">
+                    <default
+                        jcr:lastModified="{Date}2020-08-31T17:45:15.554+10:00"
+                        jcr:lastModifiedBy="admin"
+                        jcr:primaryType="nt:unstructured"
+                        jcr:title="AEM CIF Core Components Commerce Teaser"
+                        sling:resourceType="wcm/core/components/policy/policy">
+                        <jcr:content jcr:primaryType="nt:unstructured" />
+                        <cq:styleGroups jcr:primaryType="nt:unstructured">
+                            <item0 jcr:primaryType="nt:unstructured">
+                                <cq:styles jcr:primaryType="nt:unstructured">
+                                    <item0 cq:styleClasses="cmp-teaser-banner-light"
+                                        cq:styleId="1598234697359"
+                                        cq:styleLabel="Banner - Light"
+                                        jcr:primaryType="nt:unstructured" />
+                                    <item1 cq:styleClasses="cmp-teaser-banner-dark"
+                                        cq:styleId="1598234697563"
+                                        cq:styleLabel="Banner - Dark"
+                                        jcr:primaryType="nt:unstructured" />
+                                    <item2 cq:styleClasses="cmp-teaser-feature-left"
+                                        cq:styleId="1598234698241"
+                                        cq:styleLabel="Feature - Left"
+                                        jcr:primaryType="nt:unstructured" />
+                                    <item3 cq:styleClasses="cmp-teaser-feature-right"
+                                        cq:styleId="1598234699118"
+                                        cq:styleLabel="Feature - Right"
+                                        jcr:primaryType="nt:unstructured" />
+                                </cq:styles>
+                            </item0>
+                        </cq:styleGroups>
+                    </default>
+                </teaser>
             </commerce>
         </components>
     </venia>

--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/catalog-page/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/catalog-page/policies/.content.xml
@@ -56,6 +56,9 @@
                                 <featuredcategorylist jcr:primaryType="nt:unstructured"
                                     cq:policy="venia/components/commerce/featuredcategorylist/default"
                                     sling:resourceType="wcm/core/components/policies/mapping" />
+                                <teaser cq:policy="venia/components/commerce/teaser/default"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="wcm/core/components/policies/mapping" />
                             </commerce>
                         </components>
                     </venia>

--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/category-page/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/category-page/policies/.content.xml
@@ -59,6 +59,9 @@
                                 <featuredcategorylist jcr:primaryType="nt:unstructured"
                                     cq:policy="venia/components/commerce/featuredcategorylist/default"
                                     sling:resourceType="wcm/core/components/policies/mapping" />
+                                <teaser cq:policy="venia/components/commerce/teaser/default"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="wcm/core/components/policies/mapping" />
                             </commerce>
                         </components>
                     </venia>

--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/landing-page/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/landing-page/policies/.content.xml
@@ -56,6 +56,9 @@
                                 <featuredcategorylist jcr:primaryType="nt:unstructured"
                                     cq:policy="venia/components/commerce/featuredcategorylist/default"
                                     sling:resourceType="wcm/core/components/policies/mapping" />
+                                <teaser cq:policy="venia/components/commerce/teaser/default"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="wcm/core/components/policies/mapping" />
                             </commerce>
                         </components>
                     </venia>

--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/page-content/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/page-content/policies/.content.xml
@@ -65,6 +65,9 @@
                                 <featuredcategorylist jcr:primaryType="nt:unstructured"
                                     cq:policy="venia/components/commerce/featuredcategorylist/default"
                                     sling:resourceType="wcm/core/components/policies/mapping" />
+                                <teaser cq:policy="venia/components/commerce/teaser/default"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="wcm/core/components/policies/mapping" />
                             </commerce>
                         </components>
                     </venia>

--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/product-page/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/product-page/policies/.content.xml
@@ -56,6 +56,9 @@
                                 <featuredcategorylist jcr:primaryType="nt:unstructured"
                                     cq:policy="venia/components/commerce/featuredcategorylist/default"
                                     sling:resourceType="wcm/core/components/policies/mapping" />
+                                <teaser cq:policy="venia/components/commerce/teaser/default"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="wcm/core/components/policies/mapping" />
                             </commerce>
                         </components>
                     </venia>

--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/root-page/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/root-page/policies/.content.xml
@@ -56,6 +56,9 @@
                                 <featuredcategorylist jcr:primaryType="nt:unstructured"
                                     cq:policy="venia/components/commerce/featuredcategorylist/default"
                                     sling:resourceType="wcm/core/components/policies/mapping" />
+                                <teaser cq:policy="venia/components/commerce/teaser/default"
+                                    jcr:primaryType="nt:unstructured"
+                                    sling:resourceType="wcm/core/components/policies/mapping" />
                             </commerce>
                         </components>
                     </venia>

--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/xf-web-variation/policies/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/wcm/templates/xf-web-variation/policies/.content.xml
@@ -41,6 +41,9 @@
                         <featuredcategorylist jcr:primaryType="nt:unstructured"
                             cq:policy="venia/components/commerce/featuredcategorylist/default"
                             sling:resourceType="wcm/core/components/policies/mapping" />
+                        <teaser cq:policy="venia/components/commerce/teaser/default"
+                            jcr:primaryType="nt:unstructured"
+                            sling:resourceType="wcm/core/components/policies/mapping" />
                     </commerce>
                 </components>
             </mysite>

--- a/ui.frontend/src/main/styles/_teaser.scss
+++ b/ui.frontend/src/main/styles/_teaser.scss
@@ -1,8 +1,40 @@
-.cmp-teaser {}
-.cmp-teaser__image {}
-.cmp-teaser__content {}
-.cmp-teaser__title {}
-.cmp-teaser__title-link {}
-.cmp-teaser__description {}
-.cmp-teaser__action-container {}
-.cmp-teaser__action-link {}
+.cmp-teaser {
+}
+.cmp-teaser__image {
+}
+.cmp-teaser__content {
+}
+.cmp-teaser__title {
+    font-size: 40px !important;
+    font-weight: 600 !important;
+    max-width: 400px;
+    margin-bottom: 10px;
+    text-align: left;
+    line-height: 1.25em;
+    letter-spacing: 0.32px;
+    opacity: 1;
+}
+.cmp-teaser__title-link {
+}
+.cmp-teaser__description {
+    margin-bottom: 1rem;
+    line-height: 1.5em;
+    font-size: 14px;
+}
+.cmp-teaser__action-container {
+}
+.cmp-teaser__action-link {
+    align-items: center;
+    border-radius: 1.25rem;
+    display: inline-flex;
+    font-size: 14px !important;
+    font-weight: 700 !important;
+    height: 2.5rem;
+    justify-content: center;
+    letter-spacing: 0.25px;
+    margin-right: 0.75rem;
+    margin-top: 0.75rem;
+    min-width: 12rem;
+    text-decoration: none !important;
+    text-transform: uppercase;
+}

--- a/ui.frontend/src/main/styles/teaser/_banner-dark.scss
+++ b/ui.frontend/src/main/styles/teaser/_banner-dark.scss
@@ -1,0 +1,19 @@
+.cmp-teaser-banner-dark {
+    .cmp-teaser__content {
+        margin-top: -500px;
+        height: 300px;
+        min-height: 300px;
+        float: left;
+        position: relative;
+        width: 574px;
+        margin-left: 133px;
+    }
+    .cmp-teaser__title {
+        text-align: left;
+    }
+    .cmp-teaser__action-link {
+        border: 2px solid #00f;
+        background-color: #00f;
+        color: white;
+    }
+}

--- a/ui.frontend/src/main/styles/teaser/_banner-light.scss
+++ b/ui.frontend/src/main/styles/teaser/_banner-light.scss
@@ -1,0 +1,23 @@
+.cmp-teaser-banner-light {
+    .cmp-teaser__content {
+        margin-top: -500px;
+        height: 300px;
+        min-height: 300px;
+        float: left;
+        position: relative;
+        width: 574px;
+        margin-left: 133px;
+    }
+    .cmp-teaser__title {
+        text-align: left;
+        color: white;
+    }
+    .cmp-teaser__description {
+        color: white;
+    }
+    .cmp-teaser__action-link {
+        border: 2px solid #00f;
+        background-color: #00f;
+        color: white;
+    }
+}

--- a/ui.frontend/src/main/styles/teaser/_feature-left.scss
+++ b/ui.frontend/src/main/styles/teaser/_feature-left.scss
@@ -1,0 +1,25 @@
+.cmp-teaser-feature-left {
+    padding-top: 10px;
+    padding-bottom: 10px;
+
+    .cmp-teaser {
+        display: flex;
+        flex-direction: row-reverse;
+        overflow: hidden;
+    }
+    .cmp-teaser__image {
+        object-fit: contain;
+    }
+
+    .cmp-teaser__content {
+        padding: 5rem 2rem !important;
+    }
+    .cmp-teaser__title {
+        color: $venia-text;
+    }
+    .cmp-teaser__action-link {
+        border: 2px solid #00f;
+        background-color: white;
+        color: #00f;
+    }
+}

--- a/ui.frontend/src/main/styles/teaser/_feature-right.scss
+++ b/ui.frontend/src/main/styles/teaser/_feature-right.scss
@@ -1,0 +1,25 @@
+.cmp-teaser-feature-right {
+    padding-top: 10px;
+    padding-bottom: 10px;
+
+    .cmp-teaser {
+        display: flex;
+        flex-direction: row;
+        overflow: hidden;
+    }
+    .cmp-teaser__image {
+        object-fit: contain;
+    }
+    .cmp-teaser__content {
+        padding: 5rem 2rem !important;
+    }
+    .cmp-teaser__title {
+        text-align: left;
+        color: $venia-text;
+    }
+    .cmp-teaser__action-link {
+        border: 2px solid #00f;
+        background-color: white;
+        color: #00f;
+    }
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add commerce teaser styles & corresponding policies to add 4 predefined styles that can be used by authors.
The PR added 4 sample styles:
* Banner - light
* Banner - dark
* Feature - left
* Feature - right

## Related Issue

CIF-1673

## Motivation and Context

Component should have some default styling.

## How Has This Been Tested?

manually

## Screenshots (if appropriate):

![Screenshot 2020-10-14 at 09 48 40](https://user-images.githubusercontent.com/2643450/95959225-7aece100-0e02-11eb-92f0-4c2cf66780bf.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.