### PR TITLE
CIF-1678 - Commerce Teaser should align HTL files with WCM core component

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/teaser/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/teaser/.content.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     cq:icon="card"
-    jcr:description="Content Teaser"
+    jcr:description="Commerce Teaser"
     jcr:primaryType="cq:Component"
-    jcr:title="Content Teaser"
+    jcr:title="Commerce Teaser"
     sling:resourceSuperType="core/cif/components/content/teaser/v1/teaser"
     imageDelegate="venia/components/image"
     componentGroup="Venia - Commerce"/>

--- a/ui.frontend/src/main/styles/_teaser.scss
+++ b/ui.frontend/src/main/styles/_teaser.scss
@@ -4,6 +4,8 @@
 }
 .cmp-teaser__content {
 }
+.cmp-teaser__pretitle {
+}
 .cmp-teaser__title {
     font-size: 40px !important;
     font-weight: 600 !important;


### PR DESCRIPTION
 * updated commerce teaser to latest Core WCM teaser
 * user commerce teaser name consistently

## Related Issue

CIF-1678

## How Has This Been Tested?

Manually.


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.