### PR TITLE
CIF-1512 - Dynamic XF on PDP

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/experiencefragment/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/experiencefragment/.content.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:description="Commerce Experience Fragment container"
+    jcr:primaryType="cq:Component"
+    jcr:title="Commerce Experience Fragment"
+    sling:resourceSuperType="core/cif/components/commerce/experiencefragment/v1/experiencefragment"
+    componentGroup="Venia - Commerce"/>

--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/xfpage/_cq_dialog/.content-cloud.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/xfpage/_cq_dialog/.content-cloud.xml
@@ -94,6 +94,19 @@
                                                 targetProperty="jcr:content/cq:products"/>
                                         </items>
                                     </productsPickerSection>
+                                    <fragmentLocationSection
+                                        jcr:primaryType="nt:unstructured"
+                                        jcr:title="Fragment Location"
+                                        sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <fragmentLocation
+                                                jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldDescription="This must match the location defined on pages with the commerce experience fragment component."
+                                                fieldLabel="The location of the experience fragment (can be empty)."
+                                                name="./fragmentLocation"/>
+                                        </items>
+                                    </fragmentLocationSection>
                                 </items>
                             </column>
                         </items>


### PR DESCRIPTION
- Add commerce experience fragment proxy component

New component provided by https://github.com/adobe/aem-core-cif-components/pull/458

- Also adds the configuration to set the fragment location

![Screenshot 2021-01-07 at 12 18 02](https://user-images.githubusercontent.com/24548615/103899465-bb54b600-50f6-11eb-98ee-721a96d2bb83.png)

## How Has This Been Tested?

Manually tested.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.