### PR TITLE
CIF-1614 - enable the usage for publish server graphql reverse proxy

### DIFF
--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/cloudconfigs/commerce/.content-cloud.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/cloudconfigs/commerce/.content-cloud.xml
@@ -6,5 +6,6 @@
         jcr:title="Commerce"
         sling:configPropertyInherit="true"
         cq:template="/libs/cif/shell/components/configuration/page/template"
-        sling:resourceType="cif/shell/components/configuration/page"/>
+        sling:resourceType="cif/shell/components/configuration/page"
+        usePublishGraphqlEndpoint="true"/>
 </jcr:root>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Enable the usage for publish server graphql reverse proxy by default for the cloud profile. This PR relates to https://github.com/adobe/aem-core-cif-components/pull/459

## Related Issue

CIF-1614

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.