### PR TITLE
CIF-1674 - Add UI tests for component dialogs

### DIFF
--- a/.circleci/ci/it-tests.js
+++ b/.circleci/ci/it-tests.js
@@ -24,6 +24,7 @@ try {
     let veniaVersion = ci.sh('mvn help:evaluate -Dexpression=project.version -q -DforceStdout', true);
     let cifVersion = ci.sh('mvn help:evaluate -Dexpression=core.cif.components.version -q -DforceStdout', true);
     let wcmVersion = ci.sh('mvn help:evaluate -Dexpression=core.wcm.components.version -q -DforceStdout', true);
+    let connectorVersion = '1.6.0';
     let graphqlClientVersion = ci.sh('mvn help:evaluate -Dexpression=graphql.client.version -q -DforceStdout', true);
     let classifier = process.env.AEM;
 
@@ -34,6 +35,9 @@ try {
         // We install the graphql-client by default except with the CIF Add-On
         let extras = `--bundle com.adobe.commerce.cif:graphql-client:${graphqlClientVersion}:jar`;
         if (classifier == 'classic') {
+            // Install CIF connector
+            extras += ` --bunlde com.adobe.commerce.cif:cif-connector.all:${connectorVersion}:zip`;
+
             // The core components are already installed in the Cloud SDK
             extras += ` --bundle com.adobe.cq:core.wcm.components.all:${wcmVersion}:zip`;
         } else if (classifier == 'cloud') {

--- a/.circleci/ci/it-tests.js
+++ b/.circleci/ci/it-tests.js
@@ -36,7 +36,7 @@ try {
         let extras = `--bundle com.adobe.commerce.cif:graphql-client:${graphqlClientVersion}:jar`;
         if (classifier == 'classic') {
             // Install CIF connector
-            extras += ` --bunlde com.adobe.commerce.cif:cif-connector-all:${connectorVersion}:zip`;
+            extras += ` --bundle com.adobe.commerce.cif:cif-connector-all:${connectorVersion}:zip`;
 
             // The core components are already installed in the Cloud SDK
             extras += ` --bundle com.adobe.cq:core.wcm.components.all:${wcmVersion}:zip`;

--- a/.circleci/ci/it-tests.js
+++ b/.circleci/ci/it-tests.js
@@ -36,7 +36,7 @@ try {
         let extras = `--bundle com.adobe.commerce.cif:graphql-client:${graphqlClientVersion}:jar`;
         if (classifier == 'classic') {
             // Install CIF connector
-            extras += ` --bunlde com.adobe.commerce.cif:cif-connector.all:${connectorVersion}:zip`;
+            extras += ` --bunlde com.adobe.commerce.cif:cif-connector-all:${connectorVersion}:zip`;
 
             // The core components are already installed in the Cloud SDK
             extras += ` --bundle com.adobe.cq:core.wcm.components.all:${wcmVersion}:zip`;

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
         <core.wcm.components.version>2.10.0</core.wcm.components.version>
-        <core.cif.components.version>1.6.0</core.cif.components.version>
+        <core.cif.components.version>1.6.1-SNAPSHOT</core.cif.components.version>
         <graphql.client.version>1.7.0</graphql.client.version>
         <magento.graphql.version>6.0.0-magento235</magento.graphql.version>
         <bnd.version>5.1.2</bnd.version>

--- a/ui.tests/test-module/lib/commons.js
+++ b/ui.tests/test-module/lib/commons.js
@@ -13,13 +13,18 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-const conf   = require('./config');
+const conf = require('./config');
 const moment = require('moment');
-const path   = require('path');
+const path = require('path');
 const request = require('request-promise');
 const tough = require('tough-cookie');
+const { randomBytes } = require('crypto');
 
-const AEMSitesViewTypes = Object.freeze({'CARD': 'card', 'COLUMN': 'column', 'LIST': 'list'});
+const AEMSitesViewTypes = Object.freeze({ CARD: 'card', COLUMN: 'column', LIST: 'list' });
+
+const KEYS = {
+    enter: '\uE007'
+};
 
 function takeScreenshot(browser, prefix) {
     prefix = prefix == null ? '' : prefix + '-';
@@ -59,6 +64,10 @@ function _getLoginTokenCookie(browser) {
     });
 }
 
+function randomString() {
+    return randomBytes(10).toString('hex');
+}
+
 class OnboardingDialogHandler {
     constructor(browser) {
         this.browser = browser;
@@ -68,12 +77,12 @@ class OnboardingDialogHandler {
     enable() {
         this.beforeCmdBkp = this.browser.config.beforeCommand || [];
 
-        this.browser.config.beforeCommand.push(function() {
-            if($('coral-overlay[class*="onboarding"]').isDisplayedInViewport()) {
+        this.browser.config.beforeCommand.push(function () {
+            if ($('coral-overlay[class*="onboarding"]').isDisplayedInViewport()) {
                 console.log('User Onboarding Dialog is present, closing it.');
                 // console.log(arguments);
                 browser.keys('Escape');
-                $('coral-overlay[class*="onboarding"]').waitForDisplayed({reverse: true});
+                $('coral-overlay[class*="onboarding"]').waitForDisplayed({ reverse: true });
             }
         });
     }
@@ -84,8 +93,10 @@ class OnboardingDialogHandler {
 }
 
 module.exports = {
-    AEMSitesViewTypes: AEMSitesViewTypes,
-    getAuthenticatedRequestOptions: getAuthenticatedRequestOptions,
-    takeScreenshot: takeScreenshot,
-    OnboardingDialogHandler: OnboardingDialogHandler
+    AEMSitesViewTypes,
+    getAuthenticatedRequestOptions,
+    takeScreenshot,
+    OnboardingDialogHandler,
+    KEYS,
+    randomString
 };

--- a/ui.tests/test-module/lib/wdio.commands.js
+++ b/ui.tests/test-module/lib/wdio.commands.js
@@ -28,10 +28,9 @@ browser.addCommand('AEMLogin', function (username, password) {
     if ($('[class*="Accordion"] form').isExisting()) {
         try {
             $('#username').setValue(username);
-        }
-        // Form field not interactable, not visible
-        // Need to open the Accordion
-        catch (e) {
+        } catch (e) {
+            // Form field not interactable, not visible
+            // Need to open the Accordion
             $('[class*="Accordion"] button').click();
             browser.pause(500);
         }
@@ -55,33 +54,22 @@ browser.addCommand('AEMForceLogout', function () {
     $('form[name="login"]').waitForExist();
 });
 
-browser.addCommand('configureGraphqlClient', async function (factoryPid, properties) {
-    const auth = commons.getAuthenticatedRequestOptions(browser);
+/**
+ * Close all additional windows which might have been opened by a test.
+ */
+browser.addCommand('CloseOtherWindows', function () {
+    const handles = browser.getWindowHandles();
 
-    // Update OSGi config of GraphQL client
-    const configurations = await getOsgiConfigurations(auth, factoryPid);
-    const pid = configurations.length > 0 ? configurations[0].pid : '';
-    await editOsgiConfiguration(auth, pid, factoryPid, properties);
+    if (handles.length <= 1) return;
 
-    // Update OSGi config of Sling Authenticator to make GraphQL servlet reachable
-    await editOsgiConfiguration(auth, 'org.apache.sling.engine.impl.auth.SlingAuthenticator', null, {
-        'auth.sudo.cookie': 'sling.sudo',
-        'auth.sudo.parameter': 'sudo',
-        'auth.annonymous': 'false',
-        'sling.auth.requirements': [
-            '+/',
-            '-/libs/granite/core/content/login',
-            '-/etc.clientlibs',
-            '-/etc/clientlibs/granite',
-            '-/libs/dam/remoteassets/content/loginerror',
-            '-/apps/cif-components-examples/graphql'
-        ],
-        'sling.auth.anonymous.user': '',
-        'sling.auth.anonymous.password': 'unmodified',
-        'auth.http': 'preemptive',
-        'auth.http.realm': 'Sling+(Development)',
-        'auth.uri.suffix': '/j_security_check'
-    });
+    // Close all windows except for the first
+    for (let i = 1; i < handles.length; i++) {
+        browser.switchToWindow(handles[i]);
+        browser.closeWindow();
+    }
+
+    // Switch back to the first window
+    browser.switchToWindow(handles[0]);
 });
 
 // Returns file handle to use for file upload component,
@@ -110,14 +98,38 @@ browser.addCommand('AEMPathExists', function (baseUrl, path) {
         });
 });
 
-browser.addCommand('AEMDeleteAsset', function (assetPath) {
+browser.addCommand('AEMEditorLoaded', function () {
+    // Check for two conditions in the browse JavaScript context.
+    // Taken from https://git.corp.adobe.com/CQ/selenium-it-base/blob/45815ecf4c509aefcc9872ad1be4d978875ee81d/src/main/java/com/adobe/qe/selenium/pageobject/EditorPage.java#L191-L197
+    browser.waitUntil(() => {
+        // eslint-disable-next-line
+        return browser.execute(() => window && window.Granite && window.Granite.author && true);
+    });
+
+    browser.waitUntil(() => {
+        return browser.execute(() => {
+            // eslint-disable-next-line
+            if (window && window.Granite && window.Granite.author && true) {
+                // eslint-disable-next-line
+                var ns = window.Granite.author;
+                return ns.pageInfo && ns.pageInfo !== null;
+            }
+            return false;
+        });
+    });
+});
+
+/**
+ * Delete a page at the given path.
+ */
+browser.addCommand('AEMDeletePage', function (path) {
     let options = commons.getAuthenticatedRequestOptions(browser);
     Object.assign(options, {
         formData: {
             cmd: 'deletePage',
-            path: assetPath,
+            path,
             force: 'true',
-            '_charset_': 'utf-8'
+            _charset_: 'utf-8'
         }
     });
 
@@ -139,13 +151,37 @@ browser.addCommand('AEMSitesSetView', function (type) {
     browser.refresh();
 });
 
+/**
+ * Create a new page.
+ */
+browser.addCommand('AEMCreatePage', function (pageOptions) {
+    let options = commons.getAuthenticatedRequestOptions(browser);
+    const { title, name, parent, template } = pageOptions;
+    Object.assign(options, {
+        formData: {
+            './jcr:title': title,
+            pageName: name,
+            parentPath: parent,
+            template,
+            _charset_: 'utf-8'
+        }
+    });
+
+    return request.post(
+        url.resolve(config.aem.author.base_url, '/libs/wcm/core/content/sites/createpagewizard/_jcr_content'),
+        options
+    );
+});
+
 browser.addCommand('AEMSitesSetPageTitle', function (parentPath, name, title) {
     let originalTitle = '';
 
     // Navigate to page parent path
     browser.url(path.posix.join(AEM_SITES_PATH, parentPath));
     // Select sample page in the list
-    $(`[data-foundation-collection-item-id="${path.posix.join(parentPath, name)}"] [type="checkbox"]`).waitForClickable();
+    $(
+        `[data-foundation-collection-item-id="${path.posix.join(parentPath, name)}"] [type="checkbox"]`
+    ).waitForClickable();
     browser.pause(1000); // Avoid action bar not appearing after clicking checkbox
     $(`[data-foundation-collection-item-id="${path.posix.join(parentPath, name)}"] [type="checkbox"]`).click();
     // Access page properties form
@@ -162,31 +198,26 @@ browser.addCommand('AEMSitesSetPageTitle', function (parentPath, name, title) {
     return originalTitle;
 });
 
-async function getOsgiConfigurations(auth, factoryPid) {
-    const options = { ...auth, method: 'GET', uri: url.resolve(config.aem.author.base_url, '/system/console/configMgr/*.json'), json: true };
+browser.addCommand(
+    'waitAndClick',
+    function (args) {
+        this.waitForDisplayed();
+        this.click(args);
+    },
+    true
+);
 
-    const configurations = await request(options);
-    const configuration = configurations.filter(c => c.factoryPid === factoryPid);
-
-    return configuration;
-}
-
-async function editOsgiConfiguration(auth, pid, factoryPid, properties) {
-    const form = {
-        apply: 'true',
-        action: 'ajaxConfigManager',
-        propertylist: Object.keys(properties).join(','),
-        _charset_: 'utf-8',
-        ...properties
-    };
-    if (factoryPid) {
-        form.factoryPid = factoryPid;
+/**
+ * Opens the side panel in the AEM Sites editor if closed.
+ */
+browser.addCommand('EditorOpenSidePanel', function () {
+    const toggleButton = $('button[title="Toggle Side Panel"]');
+    toggleButton.waitForDisplayed();
+    const sidePanel = $('#SidePanel.sidepanel-opened');
+    if (!sidePanel.isDisplayed()) {
+        toggleButton.click();
     }
-
-    const options = { ...auth, method: 'POST', uri: url.resolve(config.aem.author.base_url, `/system/console/configMgr/${pid}`), form, simple: false, resolveWithFullResponse: true, useQuerystring: true };
-    const { statusCode } = await request(options);
-    expect(statusCode).toEqual(302);
-}
+});
 
 async function fileHandle(filePath) {
     if (config.upload_url) {
@@ -212,7 +243,7 @@ function fileHandleByUploadUrl(uploadUrl, filePath) {
                 options: {
                     filename: path.basename(filePath)
                 }
-            },
-        },
+            }
+        }
     });
 }

--- a/ui.tests/test-module/lib/wdio.commands.js
+++ b/ui.tests/test-module/lib/wdio.commands.js
@@ -54,6 +54,35 @@ browser.addCommand('AEMForceLogout', function () {
     $('form[name="login"]').waitForExist();
 });
 
+browser.addCommand('configureGraphqlClient', async function (factoryPid, properties) {
+    const auth = commons.getAuthenticatedRequestOptions(browser);
+
+    // Update OSGi config of GraphQL client
+    const configurations = await getOsgiConfigurations(auth, factoryPid);
+    const pid = configurations.length > 0 ? configurations[0].pid : '';
+    await editOsgiConfiguration(auth, pid, factoryPid, properties);
+
+    // Update OSGi config of Sling Authenticator to make GraphQL servlet reachable
+    await editOsgiConfiguration(auth, 'org.apache.sling.engine.impl.auth.SlingAuthenticator', null, {
+        'auth.sudo.cookie': 'sling.sudo',
+        'auth.sudo.parameter': 'sudo',
+        'auth.annonymous': 'false',
+        'sling.auth.requirements': [
+            '+/',
+            '-/libs/granite/core/content/login',
+            '-/etc.clientlibs',
+            '-/etc/clientlibs/granite',
+            '-/libs/dam/remoteassets/content/loginerror',
+            '-/apps/cif-components-examples/graphql'
+        ],
+        'sling.auth.anonymous.user': '',
+        'sling.auth.anonymous.password': 'unmodified',
+        'auth.http': 'preemptive',
+        'auth.http.realm': 'Sling+(Development)',
+        'auth.uri.suffix': '/j_security_check'
+    });
+});
+
 /**
  * Close all additional windows which might have been opened by a test.
  */
@@ -218,6 +247,32 @@ browser.addCommand('EditorOpenSidePanel', function () {
         toggleButton.click();
     }
 });
+
+async function getOsgiConfigurations(auth, factoryPid) {
+    const options = { ...auth, method: 'GET', uri: url.resolve(config.aem.author.base_url, '/system/console/configMgr/*.json'), json: true };
+
+    const configurations = await request(options);
+    const configuration = configurations.filter(c => c.factoryPid === factoryPid);
+
+    return configuration;
+}
+
+async function editOsgiConfiguration(auth, pid, factoryPid, properties) {
+    const form = {
+        apply: 'true',
+        action: 'ajaxConfigManager',
+        propertylist: Object.keys(properties).join(','),
+        _charset_: 'utf-8',
+        ...properties
+    };
+    if (factoryPid) {
+        form.factoryPid = factoryPid;
+    }
+
+    const options = { ...auth, method: 'POST', uri: url.resolve(config.aem.author.base_url, `/system/console/configMgr/${pid}`), form, simple: false, resolveWithFullResponse: true, useQuerystring: true };
+    const { statusCode } = await request(options);
+    expect(statusCode).toEqual(302);
+}
 
 async function fileHandle(filePath) {
     if (config.upload_url) {

--- a/ui.tests/test-module/specs/venia/component-dialogs.js
+++ b/ui.tests/test-module/specs/venia/component-dialogs.js
@@ -71,6 +71,7 @@ describe('Component Dialogs', function() {
         // Filter for Commerce components
         $('#components-filter coral-select').waitAndClick();
         $(`coral-selectlist-item[value="${group}"]`).waitAndClick();
+        expect($('#components-filter coral-select coral-button-label')).toHaveText(group);
 
         // Drag category carousel component on page
         const carouselCmp = $(`div[data-title="${name}"]`);

--- a/ui.tests/test-module/specs/venia/component-dialogs.js
+++ b/ui.tests/test-module/specs/venia/component-dialogs.js
@@ -17,11 +17,13 @@
 const config = require('../../lib/config');
 const { OnboardingDialogHandler, randomString } = require('../../lib/commons');
 
-describe('Category Carousel', () => {
+describe('Category Carousel', function() {
     const editor_page = `${config.aem.author.base_url}/editor.html`;
 
     let testing_page;
     let onboardingHdler;
+
+    this.retries(2);
 
     before(() => {
         // Set window size to desktop

--- a/ui.tests/test-module/specs/venia/component-dialogs.js
+++ b/ui.tests/test-module/specs/venia/component-dialogs.js
@@ -94,36 +94,53 @@ describe('Category Carousel', () => {
     it('opens the category carousel dialog', () => {
         addComponentToPage('Category Carousel');
         openComponentDialog('categorycarousel', 'aem:sites:components:dialogs:cif-core-components:categorycarousel:v1');
+
+        $('coral-multifield button').click();
+        expect($('coral-multifield-item').$('label=Category')).toBeDisplayed();
     });
 
     it('opens the commerce experience fragment dialog', () => {
         addComponentToPage('Commerce Experience Fragment');
         openComponentDialog('experiencefragment', 'aem:sites:components:dialogs:cif-core-components:experiencefragment:v1');
+
+        expect($('label=Experience fragment location name.')).toBeDisplayed();
     });
 
     it('opens the commerce teaser dialog', () => {
         addComponentToPage('Commerce Teaser');
         openComponentDialog('teaser', 'aem:sites:components:dialogs:cif-core-components:teaser:v1');
+
+        $('coral-tab-label=Link & Actions').click();
+        expect($('label=Link')).toBeDisplayed();
     });
 
     it('opens the featured categories dialog', () => {
         addComponentToPage('Featured Categories');
         openComponentDialog('featuredcategorylist', 'aem:sites:components:dialogs:cif-core-components:featuredcategorylist:v1');
+
+        $('coral-multifield button').click();
+        expect($('coral-multifield-item').$('label=Category')).toBeDisplayed();
     });
 
     it('opens the product carousel dialog', () => {
         addComponentToPage('Product Carousel');
         openComponentDialog('productcarousel', 'aem:sites:components:dialogs:cif-core-components:productcarousel:v1');
+
+        expect($('label=Carousel content')).toBeDisplayed();
     });
 
     it('opens the product teaser dialog', () => {
         addComponentToPage('Product Teaser');
         openComponentDialog('productteaser', 'aem:sites:components:dialogs:cif-core-components:productteaser:v1');
+
+        expect($('label=Select Product')).toBeDisplayed();
     });
 
-    it('opens the product teaser dialog', () => {
+    it('opens the releated products dialog', () => {
         addComponentToPage('Related Products');
         openComponentDialog('relatedproducts', 'aem:sites:components:dialogs:cif-core-components:relatedproducts:v1');
+
+        expect($('label=Base product - Leave empty to use the current product of the generic product page.')).toBeDisplayed();
     });
 
 });

--- a/ui.tests/test-module/specs/venia/component-dialogs.js
+++ b/ui.tests/test-module/specs/venia/component-dialogs.js
@@ -17,7 +17,7 @@
 const config = require('../../lib/config');
 const { OnboardingDialogHandler, randomString } = require('../../lib/commons');
 
-describe('Category Carousel', function() {
+describe('Component Dialogs', function() {
     const editor_page = `${config.aem.author.base_url}/editor.html`;
 
     let testing_page;

--- a/ui.tests/test-module/specs/venia/component-dialogs.js
+++ b/ui.tests/test-module/specs/venia/component-dialogs.js
@@ -1,0 +1,129 @@
+/*
+ *  Copyright 2020 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+const config = require('../../lib/config');
+const { OnboardingDialogHandler, randomString } = require('../../lib/commons');
+
+describe('Category Carousel', () => {
+    const editor_page = `${config.aem.author.base_url}/editor.html`;
+
+    let testing_page;
+    let onboardingHdler;
+
+    before(() => {
+        // Set window size to desktop
+        browser.setWindowSize(1280, 960);
+
+        // AEM Login
+        browser.AEMForceLogout();
+        browser.url(config.aem.author.base_url);
+        browser.AEMLogin(config.aem.author.username, config.aem.author.password);
+
+        // Enable helper to handle onboarding dialog popup
+        onboardingHdler = new OnboardingDialogHandler(browser);
+        onboardingHdler.enable();
+    });
+
+    after(function () {
+        // Disable helper to handle onboarding dialog popup
+        onboardingHdler.disable();
+    });
+
+    beforeEach(() => {
+        const pageName = `testing-${randomString()}`;
+        testing_page = `/content/venia/us/en/${pageName}`;
+        browser.AEMCreatePage({
+            title: 'Testing Page',
+            name: pageName,
+            parent: '/content/venia/us/en',
+            template: '/conf/venia/settings/wcm/templates/page-content'
+        });
+        browser.pause(1000);
+    });
+
+    afterEach(() => {
+        browser.AEMDeletePage(testing_page);
+    });
+
+    const addComponentToPage = (name, group = 'Venia - Commerce') => {
+        browser.url(`${editor_page}${testing_page}.html`);
+        browser.AEMEditorLoaded();
+        browser.EditorOpenSidePanel();
+
+        // Open the Components tab
+        $('coral-tab[title="Components"]').waitAndClick({ x: 1, y: 1 });
+
+        // Filter for Commerce components
+        $('#components-filter coral-select').waitAndClick();
+        $(`coral-selectlist-item[value="${group}"]`).waitAndClick();
+
+        // Drag category carousel component on page
+        const carouselCmp = $(`div[data-title="${name}"]`);
+        expect(carouselCmp).toBeDisplayed();
+        const dropTarget = $(`div[data-path="${testing_page}/jcr:content/root/container/container/*"]`);
+        carouselCmp.dragAndDrop(dropTarget, 1000);
+    };
+
+    const openComponentDialog = (node, trackingId) => {
+        // Open component dialog
+        const cmpPlaceholder = $(
+            `div[data-path="${testing_page}/jcr:content/root/container/container/${node}"]`
+        );
+        expect(cmpPlaceholder).toBeDisplayed();
+        cmpPlaceholder.click();
+        const configureButton = $('button[title="Configure"]');
+        expect(configureButton).toBeDisplayed();
+        configureButton.click();
+        const dialog = $(`coral-dialog[trackingfeature="${trackingId}"]`);
+        expect(dialog).toBeDisplayed();
+    };
+
+    it('opens the category carousel dialog', () => {
+        addComponentToPage('Category Carousel');
+        openComponentDialog('categorycarousel', 'aem:sites:components:dialogs:cif-core-components:categorycarousel:v1');
+    });
+
+    it('opens the commerce experience fragment dialog', () => {
+        addComponentToPage('Commerce Experience Fragment');
+        openComponentDialog('experiencefragment', 'aem:sites:components:dialogs:cif-core-components:experiencefragment:v1');
+    });
+
+    it('opens the commerce teaser dialog', () => {
+        addComponentToPage('Commerce Teaser');
+        openComponentDialog('teaser', 'aem:sites:components:dialogs:cif-core-components:teaser:v1');
+    });
+
+    it('opens the featured categories dialog', () => {
+        addComponentToPage('Featured Categories');
+        openComponentDialog('featuredcategorylist', 'aem:sites:components:dialogs:cif-core-components:featuredcategorylist:v1');
+    });
+
+    it('opens the product carousel dialog', () => {
+        addComponentToPage('Product Carousel');
+        openComponentDialog('productcarousel', 'aem:sites:components:dialogs:cif-core-components:productcarousel:v1');
+    });
+
+    it('opens the product teaser dialog', () => {
+        addComponentToPage('Product Teaser');
+        openComponentDialog('productteaser', 'aem:sites:components:dialogs:cif-core-components:productteaser:v1');
+    });
+
+    it('opens the product teaser dialog', () => {
+        addComponentToPage('Related Products');
+        openComponentDialog('relatedproducts', 'aem:sites:components:dialogs:cif-core-components:relatedproducts:v1');
+    });
+
+});

--- a/ui.tests/test-module/specs/venia/component-dialogs.js
+++ b/ui.tests/test-module/specs/venia/component-dialogs.js
@@ -69,9 +69,10 @@ describe('Component Dialogs', function() {
         $('coral-tab[title="Components"]').waitAndClick({ x: 1, y: 1 });
 
         // Filter for Commerce components
-        $('#components-filter coral-select').waitAndClick();
+        $('#components-filter coral-select button').waitAndClick();
+        browser.pause(200);
         $(`coral-selectlist-item[value="${group}"]`).waitAndClick();
-        expect($('#components-filter coral-select coral-button-label')).toHaveText(group);
+        expect($('#components-filter coral-select [handle=label]')).toHaveText(group);
 
         // Drag category carousel component on page
         const carouselCmp = $(`div[data-title="${name}"]`);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Adding some additional UI tests which check that components can be used in the Sites editor and that their dialogs work.
* Added CIF Connector to the IT test setup, otherwise the product and category picker fields don't work on AEM 6.5.
* Updated dependency to CIF core components to 1.6.1-SNAPSHOT to include the Commerce Experience Fragment component.

## How Has This Been Tested?

Tests run on CircleCI for 6.5 and AEMaaCS.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.