### PR TITLE
CIF-1818: Category reference tab + picker for Experience Fragments

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/xfpage/_cq_dialog/.content-cloud.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/xfpage/_cq_dialog/.content-cloud.xml
@@ -106,7 +106,6 @@
                                                     fieldLabel="Category IDs."
                                                     multiple="{Boolean}true"
                                                     name="./cq:categories"
-                                                    rootPath="/var/commerce/products"
                                                     selectionId="id">
                                                 <granite:data
                                                         jcr:primaryType="nt:unstructured"

--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/xfpage/_cq_dialog/.content-cloud.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/xfpage/_cq_dialog/.content-cloud.xml
@@ -94,6 +94,30 @@
                                                 targetProperty="jcr:content/cq:products"/>
                                         </items>
                                     </productsPickerSection>
+                                    <categoriesPickerSection
+                                            jcr:primaryType="nt:unstructured"
+                                            jcr:title="Category selection"
+                                            sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <categories
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="commerce/gui/components/common/cifcategoryfield"
+                                                    fieldDescription="Select the categories associated with this experience fragment variation."
+                                                    fieldLabel="Category IDs."
+                                                    multiple="{Boolean}true"
+                                                    name="./cq:categories"
+                                                    rootPath="/var/commerce/products"
+                                                    selectionId="id">
+                                                <granite:data
+                                                        jcr:primaryType="nt:unstructured"
+                                                        metaType="text"/>
+                                            </categories>
+                                            <categoriestab
+                                                    jcr:primaryType="nt:unstructured"
+                                                    sling:resourceType="commerce/gui/components/common/categoryreferencetab"
+                                                    targetProperty="jcr:content/cq:categories"/>
+                                        </items>
+                                    </categoriesPickerSection>
                                     <fragmentLocationSection
                                         jcr:primaryType="nt:unstructured"
                                         jcr:title="Fragment Location"


### PR DESCRIPTION
This adds category references to experience fragments when the project is built with the cloud profile

## Description

The feature allows users to associate experience fragments to categories and display a list of existing category associations with that XF.
The table below the category picker shows associations and the edit icon in each row should take user to the category properties page. 

## How Has This Been Tested?

Manual testing

## Screenshots:

![image](https://user-images.githubusercontent.com/53909563/105396714-1ec30580-5c18-11eb-9fd6-5ebaa1d1b483.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.