### PR TITLE
CIF-1931, CIF-1932 - rename component and XF properties field

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/experiencefragment/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/experiencefragment/.content.xml
@@ -2,6 +2,6 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:description="Commerce Experience Fragment container"
     jcr:primaryType="cq:Component"
-    jcr:title="Commerce Experience Fragment"
+    jcr:title="Commerce Experience Fragment Placeholder"
     sling:resourceSuperType="core/cif/components/commerce/experiencefragment/v1/experiencefragment"
     componentGroup="Venia - Commerce"/>

--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/xfpage/_cq_dialog/.content-cloud.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/xfpage/_cq_dialog/.content-cloud.xml
@@ -119,7 +119,7 @@
                                     </categoriesPickerSection>
                                     <fragmentLocationSection
                                         jcr:primaryType="nt:unstructured"
-                                        jcr:title="Fragment Location"
+                                        jcr:title="Catalog placeholder location"
                                         sling:resourceType="granite/ui/components/coral/foundation/form/fieldset">
                                         <items jcr:primaryType="nt:unstructured">
                                             <fragmentLocation

--- a/ui.tests/test-module/specs/venia/component-dialogs.js
+++ b/ui.tests/test-module/specs/venia/component-dialogs.js
@@ -104,7 +104,7 @@ describe('Component Dialogs', function() {
     });
 
     it('opens the commerce experience fragment dialog', () => {
-        addComponentToPage("Commerce Experience Fragment Placeholder");
+        addComponentToPage('Commerce Experience Fragment Placeholder');
         openComponentDialog('experiencefragment', 'aem:sites:components:dialogs:cif-core-components:experiencefragment:v1');
 
         expect($('label=Experience fragment location name.')).toBeDisplayed();

--- a/ui.tests/test-module/specs/venia/component-dialogs.js
+++ b/ui.tests/test-module/specs/venia/component-dialogs.js
@@ -104,7 +104,7 @@ describe('Component Dialogs', function() {
     });
 
     it('opens the commerce experience fragment dialog', () => {
-        addComponentToPage('Commerce Experience Fragment');
+        addComponentToPage("Commerce Experience Fragment Placeholder");
         openComponentDialog('experiencefragment', 'aem:sites:components:dialogs:cif-core-components:experiencefragment:v1');
 
         expect($('label=Experience fragment location name.')).toBeDisplayed();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update CIF XF component name and dialog field label. Related to https://github.com/adobe/aem-core-cif-components/pull/482

## Related Issue

CIF-1931, CIF-1932

## How Has This Been Tested?

n/a


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.