### PR TITLE
CIF-1958 - Add missing cq:lastModified property to sample XF in Venia

### DIFF
--- a/ui.content/src/main/content/jcr_root/content/experience-fragments/venia/us/en/site/footer/master/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/experience-fragments/venia/us/en/site/footer/master/.content.xml
@@ -2,6 +2,8 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
+        cq:lastModified="{Date}2021-02-24T15:59:33.287+02:00"
+        cq:lastModifiedBy="admin"
         cq:tags="[]"
         cq:template="/conf/venia/settings/wcm/templates/xf-web-variation"
         cq:xfMasterVariation="{Boolean}true"
@@ -35,9 +37,11 @@
                     </cq:responsive>
                 </text_197302128_copy>
                 <text_197302128_copy_631702609
+                    jcr:lastModified="{Date}2021-02-24T15:59:33.206+02:00"
+                    jcr:lastModifiedBy="admin"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="venia/components/text"
-                    text="&lt;p>&amp;nbsp;&lt;/p>&#xd;&#xa;&lt;p>&lt;b>About Us&lt;/b>&lt;/p>&#xd;&#xa;&lt;p>&amp;nbsp;&lt;/p>&#xd;&#xa;&lt;p>Our Story&lt;/p>&#xd;&#xa;&lt;p>&amp;nbsp;&lt;/p>&#xd;&#xa;&lt;p>Email Signup&lt;/p>&#xd;&#xa;&lt;p>&amp;nbsp;&lt;/p>&#xd;&#xa;&lt;p>Give Back&lt;/p>&#xd;&#xa;&lt;p>&amp;nbsp;&lt;/p>&#xd;&#xa;&lt;p>&amp;nbsp;&lt;/p>&#xd;&#xa;"
+                    text="&lt;p> &lt;/p>&#xd;&#xa;&lt;p>&lt;b>About Us&lt;/b>&lt;/p>&#xd;&#xa;&lt;p> &lt;/p>&#xd;&#xa;&lt;p>Our Story&lt;/p>&#xd;&#xa;&lt;p> &lt;/p>&#xd;&#xa;&lt;p>Email Signup&lt;/p>&#xd;&#xa;&lt;p> &lt;/p>&#xd;&#xa;&lt;p>Give Back&lt;/p>&#xd;&#xa;&lt;p> &lt;/p>&#xd;&#xa;&lt;p> &lt;/p>&#xd;&#xa;"
                     textIsRich="true">
                     <cq:responsive jcr:primaryType="nt:unstructured">
                         <default
@@ -86,9 +90,9 @@
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="venia/components/separator"/>
                 <text
-                    id="footerCopyright"
                     jcr:primaryType="nt:unstructured"
                     sling:resourceType="venia/components/text"
+                    id="footerCopyright"
                     text="&lt;p>Copyright 2020, Venia.&amp;nbsp;All rights reserved.&lt;/p>&#xd;&#xa;&lt;p>345 Park Avenue,&amp;nbsp;San Jose, CA 95110-2704, USA&lt;/p>&#xd;&#xa;"
                     textIsRich="true"/>
             </container>

--- a/ui.content/src/main/content/jcr_root/content/experience-fragments/venia/us/en/site/header/master/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/experience-fragments/venia/us/en/site/header/master/.content.xml
@@ -2,6 +2,8 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
+        cq:lastModified="{Date}2021-02-24T12:51:00.455+02:00"
+        cq:lastModifiedBy="admin"
         cq:tags="[]"
         cq:template="/conf/venia/settings/wcm/templates/xf-web-variation"
         cq:xfMasterVariation="{Boolean}true"
@@ -21,6 +23,8 @@
                 skipNavigationRoot="false"
                 structureDepth="1"/>
             <languagenavigation
+                jcr:lastModified="{Date}2021-02-24T12:51:00.332+02:00"
+                jcr:lastModifiedBy="admin"
                 jcr:primaryType="nt:unstructured"
                 sling:resourceType="venia/components/languagenavigation"
                 navigationRoot="/content/venia/us"

--- a/ui.content/src/main/content/jcr_root/content/experience-fragments/venia/us/en/site/products/promotions/master/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/experience-fragments/venia/us/en/site/products/promotions/master/.content.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0"
-    xmlns:cq="http://www.day.com/jcr/cq/1.0"
-    xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
-    <jcr:content cq:products="[VD09,VD03,VD08]"
+    <jcr:content
+        cq:lastModified="{Date}2021-02-24T16:00:01.525+02:00"
+        cq:lastModifiedBy="admin"
+        cq:products="[VD09,VD03,VD08]"
         cq:template="/conf/venia/settings/wcm/templates/xf-web-variation"
         cq:xfMasterVariation="{Boolean}true"
         cq:xfVariantType="web"
@@ -13,33 +13,40 @@
         jcr:title="Summer"
         sling:resourceType="venia/components/xfpage"
         fragmentLocation="bottom">
-        <root jcr:primaryType="nt:unstructured"
+        <root
+            jcr:primaryType="nt:unstructured"
             sling:resourceType="venia/components/container"
             layout="responsiveGrid">
-            <title jcr:primaryType="nt:unstructured"
+            <title
+                jcr:lastModified="{Date}2021-02-24T16:00:01.451+02:00"
+                jcr:lastModifiedBy="admin"
+                jcr:primaryType="nt:unstructured"
                 jcr:title="Cool Summer Sale Low Price"
                 sling:resourceType="venia/components/title"
                 type="h2">
                 <cq:responsive jcr:primaryType="nt:unstructured">
-                    <default jcr:primaryType="nt:unstructured"
+                    <default
+                        jcr:primaryType="nt:unstructured"
                         offset="0"
-                        width="4" />
+                        width="4"/>
                 </cq:responsive>
             </title>
-            <productteaser jcr:primaryType="nt:unstructured"
+            <productteaser
+                jcr:primaryType="nt:unstructured"
                 sling:resourceType="venia/components/commerce/productteaser"
                 age="{Long}10"
                 badge="false"
                 selection="VA11-GO-NA"
                 text="New">
                 <cq:responsive jcr:primaryType="nt:unstructured">
-                    <default jcr:primaryType="nt:unstructured"
+                    <default
+                        jcr:primaryType="nt:unstructured"
                         behavior="newline"
                         offset="0"
-                        width="4" />
+                        width="4"/>
                 </cq:responsive>
             </productteaser>
         </root>
-        <cq:metadata jcr:primaryType="nt:unstructured" />
+        <cq:metadata jcr:primaryType="nt:unstructured"/>
     </jcr:content>
 </jcr:root>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the missing `cq:lastModified` property to the master variations of the sample experience fragments

## Related Issue

<!--- Every pull request must have a reference to a GitHub or Adobe internal issue. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

CIF-1958

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.