### PR TITLE
CIF-2086: Update react-components to be in sync with CIF Components version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
                 <version>2.5.3</version>
                 <configuration>
                     <scmCommentPrefix>[maven-scm] :</scmCommentPrefix>
-                    <preparationGoals>clean install</preparationGoals>
+                    <preparationGoals>-Pcommit-changed-manifests clean install scm:add scm:checkin</preparationGoals>
                     <goals>install</goals>
                     <releaseProfiles>release</releaseProfiles>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -596,6 +596,27 @@ Bundle-DocURL:
                                     </configuration>
                                 </execution>
                             </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <id>commit-changed-npm-files</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-scm-plugin</artifactId>
+                            <configuration>
+                                <includes>ui.frontend/package.json,ui.frontend/package-lock.json</includes>
+                                <message>[maven-release-plugin] :increment Bundle-Version for ${project.version}</message>
+                                <pushChanges>false</pushChanges>
+                            </configuration>
                         </plugin>
                     </plugins>
                 </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
                 <version>2.5.3</version>
                 <configuration>
                     <scmCommentPrefix>[maven-scm] :</scmCommentPrefix>
-                    <preparationGoals>-Pcommit-changed-manifests clean install scm:add scm:checkin</preparationGoals>
+                    <preparationGoals>-Pcommit-changed-npm-files clean install scm:add scm:checkin</preparationGoals>
                     <goals>install</goals>
                     <releaseProfiles>release</releaseProfiles>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -614,7 +614,7 @@ Bundle-DocURL:
                             <artifactId>maven-scm-plugin</artifactId>
                             <configuration>
                                 <includes>ui.frontend/package.json,ui.frontend/package-lock.json</includes>
-                                <message>[maven-release-plugin] :increment Bundle-Version for ${project.version}</message>
+                                <message>[maven-release-plugin] :update react-components version to ${core.cif.components.version}</message>
                                 <pushChanges>false</pushChanges>
                             </configuration>
                         </plugin>

--- a/ui.frontend/pom.xml
+++ b/ui.frontend/pom.xml
@@ -195,21 +195,6 @@
                                     </arguments>
                                 </configuration>
                             </execution>
-                            <execution>
-                                <id>stage-package-files</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>git</executable>
-                                    <arguments>
-                                        <argument>add</argument>
-                                        <argument>package.json</argument>
-                                        <argument>package-lock.json</argument>
-                                    </arguments>
-                                </configuration>
-                            </execution>
                         </executions>
                     </plugin>
                 </plugins>

--- a/ui.frontend/pom.xml
+++ b/ui.frontend/pom.xml
@@ -75,7 +75,7 @@
                     </execution>
                 </executions>
             </plugin>
-                
+
         </plugins>
     </build>
 
@@ -160,6 +160,53 @@
                                     <arguments>
                                         <argument>run</argument>
                                         <argument>dev</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release-prepare</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>exec-maven-plugin</artifactId>
+                        <version>3.0.0</version>
+                        <executions>
+                            <execution>
+                                <id>react-components-install</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>npm</executable>
+                                    <arguments>
+                                        <argument>install</argument>
+                                        <argument>-S</argument>
+                                        <argument>@adobe/aem-core-cif-react-components@${core.cif.components.version}</argument>
+                                    </arguments>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>stage-package-files</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>exec</goal>
+                                </goals>
+                                <configuration>
+                                    <executable>git</executable>
+                                    <arguments>
+                                        <argument>add</argument>
+                                        <argument>package.json</argument>
+                                        <argument>package-lock.json</argument>
                                     </arguments>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the `react-components` version used be `ui.frontend` module to be the same as `CIF Components` version used.
Updates both `package.json` and `package-lock.json`

## Related Issue

CIF-2086

## Motivation and Context

The current version used of react-components is very old

## How Has This Been Tested?

Performed `mvn release:prepare -Prelease-prepare` locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.