### PR TITLE
CIF-2135 - Rename component to "Commerce Experience Fragment"

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/experiencefragment/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/experiencefragment/.content.xml
@@ -2,6 +2,6 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:description="Commerce Experience Fragment container"
     jcr:primaryType="cq:Component"
-    jcr:title="Commerce Experience Fragment Placeholder"
+    jcr:title="Commerce Experience Fragment"
     sling:resourceSuperType="core/cif/components/commerce/experiencefragment/v1/experiencefragment"
     componentGroup="Venia - Commerce"/>

--- a/ui.tests/test-module/specs/venia/component-dialogs.js
+++ b/ui.tests/test-module/specs/venia/component-dialogs.js
@@ -104,7 +104,7 @@ describe('Component Dialogs', function() {
     });
 
     it('opens the commerce experience fragment dialog', () => {
-        addComponentToPage('Commerce Experience Fragment Placeholder');
+        addComponentToPage('Commerce Experience Fragment');
         openComponentDialog('experiencefragment', 'aem:sites:components:dialogs:cif-core-components:experiencefragment:v1');
 
         expect($('label=Experience fragment location name.')).toBeDisplayed();


### PR DESCRIPTION
Changed title of commerce experience fragment component to "Commerce Experience Fragment".

## Related Issue

CIF-2135

## How Has This Been Tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.