### PR TITLE
CIF-2154 - Improve UI tests for commerce content fragment component

### DIFF
--- a/ui.tests/test-module/specs/venia/content-fragment-component-dialog.js
+++ b/ui.tests/test-module/specs/venia/content-fragment-component-dialog.js
@@ -335,7 +335,9 @@ describe('Commerce Content Fragment Component Dialog', function () {
 
         // save the setting and close the dialog
         doneButton.click();
-        expect(dialog.isExisting()).toBe(false);
+        browser.waitUntil(function () {
+            return !dialog.isExisting();
+        });
 
         // re-open dialog
         dialog = openComponentDialog();
@@ -442,7 +444,9 @@ describe('Commerce Content Fragment Component Dialog', function () {
 
         // save
         doneButton.click();
-        expect(dialog.isExisting()).toBe(false);
+        browser.waitUntil(function () {
+            return !dialog.isExisting();
+        });
 
         // re-open dialog
         dialog = openComponentDialog();

--- a/ui.tests/test-module/specs/venia/content-fragment-component-dialog.js
+++ b/ui.tests/test-module/specs/venia/content-fragment-component-dialog.js
@@ -224,9 +224,11 @@ describe('Commerce Content Fragment Component Dialog', function () {
         // select singleText display mode
         dialog.$('coral-radio[value="singleText"]').click();
 
-        fields = dialog.$$('coral-tabview coral-panelstack coral-panel.is-selected .coral-Form-fieldwrapper');
+        browser.waitUntil(function () {
+            fields = dialog.$$('coral-tabview coral-panelstack coral-panel.is-selected .coral-Form-fieldwrapper');
+            return fields.length === 6;
+        });
 
-        expect(fields.length).toEqual(6);
         expect(fields[4].$('label')).toHaveText('Element *');
         expect(tabs[1]).toBeDisplayed();
         expect(tabs[1]).toHaveText('Paragraph Control');


### PR DESCRIPTION
Add waitUntil block for flaky check.

## Description

Improve stability of UI test.

## Related Issue

CIF-2154

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.