### PR TITLE
CIF-2193 - use CIF page V2 component

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/page/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/page/.content.xml
@@ -2,5 +2,5 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="cq:Component"
     jcr:title="Venia Page"
-    sling:resourceSuperType="core/cif/components/structure/page/v1/page"
+    sling:resourceSuperType="core/cif/components/structure/page/v2/page"
     componentGroup=".hidden"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Implement specific category support using `urlPath` (in the page properties) instead of `uidAndUrlPath`. Relates to https://github.com/adobe/aem-core-cif-components/pull/620

## Related Issue

CIF-2193

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [x] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.