### PR TITLE
CIF-2251: adds sitemap configurations

### DIFF
--- a/dispatcher-cloud/src/conf.d/rewrites/rewrite.rules
+++ b/dispatcher-cloud/src/conf.d/rewrites/rewrite.rules
@@ -21,5 +21,5 @@ RewriteCond %{REQUEST_URI} !^/saml_login
 RewriteCond %{REQUEST_URI} !^/system
 RewriteCond %{REQUEST_URI} !^/tmp
 RewriteCond %{REQUEST_URI} !^/var
-RewriteCond %{REQUEST_URI} (.html|.jpe?g|.png|.svg)$
+RewriteCond %{REQUEST_URI} (.html|.jpe?g|.png|.svg|.xml)$
 RewriteRule ^/(.*)$ /content/${CONTENT_FOLDER_NAME}/$1 [PT,L]

--- a/dispatcher-cloud/src/conf.dispatcher.d/filters/filters.any
+++ b/dispatcher-cloud/src/conf.dispatcher.d/filters/filters.any
@@ -14,3 +14,10 @@ $include "./default_filters.any"
 #
 /0200 { /type "allow" /method "GET" /path "/content/venia/*" /selectors '[0-9-]+' /extension "html" }
 /0201 { /type "allow" /method "GET" /path "/conf/venia/settings/wcm/templates/*" /extension "svg" }
+
+#
+# Sling Sitemap filter
+#
+/0300 { /type "allow" /method "GET" /path "/content/venia/*" /selectors "sitemap-index" /extension "xml" }
+/0301 { /type "allow" /method "GET" /path "/content/venia/*" /selectors "sitemap" /extension "xml" }
+/0302 { /type "allow" /method "GET" /path "/content/venia/*" /selectors "sitemap\.[^\.\/]+-sitemap" /extension "xml" }

--- a/ui.config/src/main/content/jcr_root/apps/venia/osgiconfig/config.publish/org.apache.sling.sitemap.impl.SitemapScheduler~default.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/venia/osgiconfig/config.publish/org.apache.sling.sitemap.impl.SitemapScheduler~default.cfg.json
@@ -1,0 +1,4 @@
+{
+    "scheduler.name": "default",
+    "scheduler.expression": "0 0 0 * * ?"
+}

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/.content.xml
@@ -16,7 +16,8 @@
         jcr:primaryType="cq:PageContent" 
         jcr:title="Venia Demo Store - Home"
         navRoot="{Boolean}true" 
-        sling:resourceType="venia/components/page" 
+        sling:resourceType="venia/components/page"
+        sling:sitemapRoot="{Boolean}true"
         pageTitle="Home">
         <root jcr:primaryType="nt:unstructured"
             jcr:mixinTypes="[cq:LiveRelationship]"

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/my-account/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/my-account/.content.xml
@@ -6,6 +6,7 @@
         cq:lastModifiedBy="admin"
         cq:lastRolledout="{Date}2020-07-08T09:32:42.236+03:00"
         cq:lastRolledoutBy="admin"
+        cq:robotsTags="[noindex]"
         cq:template="/conf/venia/settings/wcm/templates/page-content"
         jcr:mixinTypes="[cq:LiveRelationship]"
         jcr:primaryType="cq:PageContent"

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/my-account/account-details/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/my-account/account-details/.content.xml
@@ -6,6 +6,7 @@
         cq:lastModifiedBy="admin"
         cq:lastRolledout="{Date}2020-09-16T18:19:01.175+03:00"
         cq:lastRolledoutBy="admin"
+        cq:robotsTags="[noindex]"
         cq:template="/conf/venia/settings/wcm/templates/page-content"
         jcr:mixinTypes="[cq:LiveRelationship]"
         jcr:primaryType="cq:PageContent"

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/my-account/address-book/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/my-account/address-book/.content.xml
@@ -6,6 +6,7 @@
         cq:lastModifiedBy="admin"
         cq:lastRolledout="{Date}2020-07-08T09:32:42.261+03:00"
         cq:lastRolledoutBy="admin"
+        cq:robotsTags="[noindex]"
         cq:template="/conf/venia/settings/wcm/templates/page-content"
         jcr:mixinTypes="[cq:LiveRelationship]"
         jcr:primaryType="cq:PageContent"

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/products/category-page/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/products/category-page/.content.xml
@@ -9,7 +9,8 @@
         jcr:primaryType="cq:PageContent" 
         jcr:title="Venia Demo Store - Category page"
         jcr:mixinTypes="[cq:LiveRelationship]" 
-        sling:resourceType="venia/components/page">
+        sling:resourceType="venia/components/page"
+        sling:sitemapRoot="{Boolean}true">
         <root
             jcr:primaryType="nt:unstructured"
             jcr:mixinTypes="[cq:LiveRelationship]" 

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/products/product-page/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/products/product-page/.content.xml
@@ -8,7 +8,8 @@
         jcr:mixinTypes="[cq:LiveRelationship]" 
         jcr:primaryType="cq:PageContent" 
         jcr:title="Venia Demo Store - Product page"
-        sling:resourceType="venia/components/page">
+        sling:resourceType="venia/components/page"
+        sling:sitemapRoot="{Boolean}true">
         <root jcr:primaryType="nt:unstructured"
             jcr:mixinTypes="[cq:LiveRelationship]"  
             sling:resourceType="venia/components/container" 

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/reset-password/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/reset-password/.content.xml
@@ -6,6 +6,7 @@
         cq:lastModifiedBy="admin"
         cq:lastRolledout="{Date}2020-09-17T16:03:08.085+02:00"
         cq:lastRolledoutBy="admin"
+        cq:robotsTags="[noindex]"
         cq:template="/conf/venia/settings/wcm/templates/page-content"
         jcr:mixinTypes="[cq:LiveRelationship]"
         jcr:primaryType="cq:PageContent"

--- a/ui.content/src/main/content/jcr_root/content/venia/us/en/search/.content.xml
+++ b/ui.content/src/main/content/jcr_root/content/venia/us/en/search/.content.xml
@@ -3,7 +3,9 @@
     xmlns:cq="http://www.day.com/jcr/cq/1.0" 
     xmlns:jcr="http://www.jcp.org/jcr/1.0" 
     jcr:primaryType="cq:Page">
-    <jcr:content cq:template="/conf/venia/settings/wcm/templates/page-content" 
+    <jcr:content
+        cq:template="/conf/venia/settings/wcm/templates/page-content"
+        cq:robotsTags="[noindex]"
         jcr:primaryType="cq:PageContent"
         jcr:mixinTypes="[cq:LiveRelationship]" 
         jcr:title="Venia Demo Store - Search Results"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds default sitemap configurations to venia to:

- generate a default sitemap at the homepage (us/en)
- exclude all the account pages from it (robots noindex)
- generate a product and category sitemap

## Related Issue

CIF-2251

## How Has This Been Tested?

Manual 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.