### PR TITLE
CIF-2210: adapt unit tests to provide mocks for injector specific annotations

### DIFF
--- a/core/src/test/java/com/venia/core/models/commerce/MyProductTeaserImplTest.java
+++ b/core/src/test/java/com/venia/core/models/commerce/MyProductTeaserImplTest.java
@@ -19,17 +19,21 @@ import com.adobe.cq.commerce.core.components.models.common.CommerceIdentifier;
 import com.adobe.cq.commerce.core.components.models.common.Price;
 import com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductRetriever;
+import com.adobe.cq.commerce.core.components.services.urls.UrlProvider;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
+import com.adobe.cq.wcm.core.components.models.Component;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.scripting.WCMBindingsConstants;
 import io.wcm.testing.mock.aem.junit5.AemContext;
 import io.wcm.testing.mock.aem.junit5.AemContextExtension;
 import junit.framework.Assert;
 
+import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.apache.sling.api.scripting.SlingBindings;
 import org.apache.sling.caconfig.ConfigurationBuilder;
 import org.apache.sling.testing.mock.sling.ResourceResolverType;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -109,19 +113,17 @@ class MyProductTeaserImplTest {
         slingBindings.setResource(teaserResource);
         slingBindings.put(WCMBindingsConstants.NAME_CURRENT_PAGE, page);
         slingBindings.put(WCMBindingsConstants.NAME_PROPERTIES, teaserResource.getValueMap());
-        try {
-            slingBindings.put("urlProvider", Mockito.mock(Class.forName( "com.adobe.cq.commerce.core.components.services.urls.UrlProvider" )));
-        } catch( ClassNotFoundException e ) {
-            //probably core-cif-components-core version < 0.10.2
-        }
+
+        context.registerService(UrlProvider.class, Mockito.mock(UrlProvider.class));
+        context.registerAdapter(SlingHttpServletRequest.class, Component.class, new Component() {});
 
         underTest = context.request().adaptTo(MyProductTeaser.class);
-        if (underTest != null) {
-            Class<? extends MyProductTeaser> clazz = underTest.getClass();
-            productTeaser = Mockito.spy((ProductTeaser)(new FieldReader(underTest, clazz.getDeclaredField("productTeaser")).read()));
-            FieldSetter.setField(underTest, clazz.getDeclaredField("productTeaser"), productTeaser);
-            FieldSetter.setField(underTest, clazz.getDeclaredField("productRetriever"), productRetriever);
-        }
+        Assertions.assertNotNull(underTest);
+
+        Class<? extends MyProductTeaser> clazz = underTest.getClass();
+        productTeaser = Mockito.spy((ProductTeaser)(new FieldReader(underTest, clazz.getDeclaredField("productTeaser")).read()));
+        FieldSetter.setField(underTest, clazz.getDeclaredField("productTeaser"), productTeaser);
+        FieldSetter.setField(underTest, clazz.getDeclaredField("productRetriever"), productRetriever);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Since we use injector specific annotations the current mock context is not precisely replicating runtime behaviour anymore. This PR fixes issues where the mock context differs from the runtime to support injector specific sling models annotations.

## Related Issue

CIF-2210 (url provider injected from sling bindings instead of osgi service registry)
CIF-2188 (adapter missing for WCM CC Component)

## How Has This Been Tested?

Unit tests

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.