### PR TITLE
CIF-2161: add classic profile to release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The project comes with the auto-public repository configured. To set up the repo
 
 The Venia demo is only released on Github but not on Maven Central like other projects like the CIF components. To perform a release, we use a dedicated profile to make sure all modules versions are updated:
 
-`mvn release:prepare release:clean`
+`mvn release:prepare release:clean -Pclassic`
 
 Releases must be done on the `main` branch.
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,9 +91,9 @@
                 <version>2.5.3</version>
                 <configuration>
                     <scmCommentPrefix>[maven-scm] :</scmCommentPrefix>
-                    <preparationGoals>clean verify -Pprepare-release</preparationGoals>
+                    <preparationGoals>clean verify -Pprepare-release -Pclassic</preparationGoals>
                     <goals>install</goals>
-                    <releaseProfiles>release</releaseProfiles>
+                    <releaseProfiles>release,classic</releaseProfiles>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <pushChanges>false</pushChanges>
                 </configuration>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The classic modules must also be in the reactor for release builds. This includes that sub executions done by the release plugin as well as the execution of the prepare mojo to start the release process

## Related Issue

CIF-2161

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.