### PR TITLE
CIF-2368 - Increase contrast ratio for product teaser title and price

### DIFF
--- a/ui.frontend/src/main/styles/commerce/_productteaser.scss
+++ b/ui.frontend/src/main/styles/commerce/_productteaser.scss
@@ -7,7 +7,6 @@
         grid-template-areas: "main";
     }
     .item__image {
-        border: #3498db 1px solid;
         display: block;
         grid-area: main;
         height: auto;
@@ -23,23 +22,23 @@
         display: block;
         top: 40%;
         left: 20%;
-        background: unset;
         text-transform: uppercase;
         font-size: 22px;
         color: #ffffff;
         font-weight: 900;
-        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.9);
+        background-color: rgba(0,0,0,0.5);
+        padding: 0.5rem;
     }
     .price {
         position: absolute;
         display: block;
         top: 45%;
         left: 20%;
-        background: unset;
         font-size: 18px;
         color: #ffffff;
         font-weight: 900;
-        text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.9);
+        background-color: rgba(0,0,0,0.5);
+        padding: 0.5rem;
 
         .regularPrice {
             text-decoration: line-through;

--- a/ui.frontend/src/main/styles/commerce/_productteaser.scss
+++ b/ui.frontend/src/main/styles/commerce/_productteaser.scss
@@ -26,7 +26,7 @@
         font-size: 22px;
         color: #ffffff;
         font-weight: 900;
-        background-color: rgba(0,0,0,0.5);
+        background-color: rgba(0,0,0,0.6);
         padding: 0.5rem;
     }
     .price {
@@ -37,7 +37,7 @@
         font-size: 18px;
         color: #ffffff;
         font-weight: 900;
-        background-color: rgba(0,0,0,0.5);
+        background-color: rgba(0,0,0,0.6);
         padding: 0.5rem;
 
         .regularPrice {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Added dark background to product teaser name and price text to achieve a higher contrast ratio on bright backgrounds (> 5.0).
* The style is inspired from the [Commerce Teaser](https://aemcomponents.dev/content/core-components-examples/library/commerce/teaser.html) component.
* Closes https://github.com/adobe/aem-core-cif-components/issues/682.

## Screenshots (if appropriate):

![Screenshot 2021-11-01 at 14 56 07](https://user-images.githubusercontent.com/4084418/139683192-3060b745-dce5-41a0-95dd-e12b85a06b4b.png)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.