### PR TITLE
CIF-2512: set tag name format to match the previous tag names

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
                     <releaseProfiles>release,classic</releaseProfiles>
                     <autoVersionSubmodules>true</autoVersionSubmodules>
                     <pushChanges>false</pushChanges>
+                    <tagNameFormat>venia-@{project.version}</tagNameFormat>
                 </configuration>
             </plugin>
             <!-- Maven Source Plugin -->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Update the release tag name format to match the names we used before we aligned our maven setup with wknd.

## Related Issue

CIF-2512

## How Has This Been Tested?

I ran a release:prepare locally without pushing and validated the git messages and git tag name.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.