### PR TITLE
CIF-2458: deploy venia cloud artefacts to maven central

### DIFF
--- a/.circleci/ci/deploy-venia.js
+++ b/.circleci/ci/deploy-venia.js
@@ -20,6 +20,7 @@ ci.context();
 
 const releaseVersion = ci.sh(`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`, true).toString().trim();
 const releaseArtifact = ci.sh(`mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout`, true).toString().trim();
+const mvnOpts = `-B -s /home/circleci/project/.circleci/settings.xml`
 
 ci.stage("Install GHR");
 ci.sh("mkdir -p tmp");
@@ -33,13 +34,13 @@ ci.sh("chmod +x ghr");
 ci.sh("mkdir -p artifacts");
 
 ci.stage("Deploy Venia Sample Project to Maven Central");
-// deploy only the cloud artifacts
-ci.sh(`mvn -B clean deploy -Prelease,ossrh`)
+// build and deploy only the cloud artifacts
+ci.sh(`mvn ${mvnOpts} clean deploy -Prelease,ossrh`)
 ci.sh(`cp all/target/${releaseArtifact}.all-${releaseVersion}.zip artifacts/${releaseArtifact}.all-${releaseVersion}.zip`);
 
 ci.stage("Deploy Venia Sample Project to GitHub");
 // build also the classic artifacts for github
-ci.sh(`mvn -B clean install -Pclassic -pl classic/ui.config,classic/ui.content,classic/dispatcher,classic/all`);
+ci.sh(`mvn ${mvnOpts} clean install -Pclassic -pl classic/ui.config,classic/ui.content,classic/dispatcher,classic/all`);
 ci.sh(`cp classic/all/target/${releaseArtifact}.all-classic-${releaseVersion}.zip artifacts/${releaseArtifact}.all-${releaseVersion}-classic.zip`);
 ci.sh(`./ghr -t ${ci.env("GITHUB_TOKEN")} \
     -u ${ci.env("CIRCLE_PROJECT_USERNAME")} \

--- a/.circleci/ci/deploy-venia.js
+++ b/.circleci/ci/deploy-venia.js
@@ -42,9 +42,9 @@ ci.stage("Deploy Venia Sample Project to GitHub");
 // build also the classic artifacts for github
 ci.sh(`mvn ${mvnOpts} clean install -Pclassic -pl classic/ui.config,classic/ui.content,classic/dispatcher,classic/all`);
 ci.sh(`cp classic/all/target/${releaseArtifact}.all-classic-${releaseVersion}.zip artifacts/${releaseArtifact}.all-${releaseVersion}-classic.zip`);
-//ci.sh(`./ghr -t ${ci.env("GITHUB_TOKEN")} \
-//    -u ${ci.env("CIRCLE_PROJECT_USERNAME")} \
-//    -r ${ci.env("CIRCLE_PROJECT_REPONAME")} \
-//    -c ${ci.env("CIRCLE_SHA1")} \
-//    -replace ${ci.env("CIRCLE_TAG")} artifacts/`);
+ci.sh(`./ghr -t ${ci.env("GITHUB_TOKEN")} \
+    -u ${ci.env("CIRCLE_PROJECT_USERNAME")} \
+    -r ${ci.env("CIRCLE_PROJECT_REPONAME")} \
+    -c ${ci.env("CIRCLE_SHA1")} \
+    -replace ${ci.env("CIRCLE_TAG")} artifacts/`);
 

--- a/.circleci/ci/deploy-venia.js
+++ b/.circleci/ci/deploy-venia.js
@@ -29,16 +29,21 @@ ci.sh(
 ci.sh("mv tmp/**/ghr ./ghr");
 ci.sh("chmod +x ghr");
 
-ci.sh("mkdir -p artifacts"); // target folder for all the build artifacts
+// target folder for all the build artifacts
+ci.sh("mkdir -p artifacts");
 
-ci.stage(`Build and install Venia`);
-ci.sh(`mvn -B clean install -Pclassic`);
+ci.stage("Deploy Venia Sample Project to Maven Central");
+// deploy only the cloud artifacts
+ci.sh(`mvn -B clean deploy -Prelease,ossrh`)
 ci.sh(`cp all/target/${releaseArtifact}.all-${releaseVersion}.zip artifacts/${releaseArtifact}.all-${releaseVersion}.zip`);
-ci.sh(`cp classic/all/target/${releaseArtifact}.all-classic-${releaseVersion}.zip artifacts/${releaseArtifact}.all-${releaseVersion}-classic.zip`);
 
 ci.stage("Deploy Venia Sample Project to GitHub");
+// build also the classic artifacts for github
+ci.sh(`mvn -B clean install -Pclassic -pl classic/ui.config,classic/ui.content,classic/dispatcher,classic/all`);
+ci.sh(`cp classic/all/target/${releaseArtifact}.all-classic-${releaseVersion}.zip artifacts/${releaseArtifact}.all-${releaseVersion}-classic.zip`);
 ci.sh(`./ghr -t ${ci.env("GITHUB_TOKEN")} \
     -u ${ci.env("CIRCLE_PROJECT_USERNAME")} \
     -r ${ci.env("CIRCLE_PROJECT_REPONAME")} \
     -c ${ci.env("CIRCLE_SHA1")} \
     -replace ${ci.env("CIRCLE_TAG")} artifacts/`);
+

--- a/.circleci/ci/deploy-venia.js
+++ b/.circleci/ci/deploy-venia.js
@@ -42,9 +42,9 @@ ci.stage("Deploy Venia Sample Project to GitHub");
 // build also the classic artifacts for github
 ci.sh(`mvn ${mvnOpts} clean install -Pclassic -pl classic/ui.config,classic/ui.content,classic/dispatcher,classic/all`);
 ci.sh(`cp classic/all/target/${releaseArtifact}.all-classic-${releaseVersion}.zip artifacts/${releaseArtifact}.all-${releaseVersion}-classic.zip`);
-ci.sh(`./ghr -t ${ci.env("GITHUB_TOKEN")} \
-    -u ${ci.env("CIRCLE_PROJECT_USERNAME")} \
-    -r ${ci.env("CIRCLE_PROJECT_REPONAME")} \
-    -c ${ci.env("CIRCLE_SHA1")} \
-    -replace ${ci.env("CIRCLE_TAG")} artifacts/`);
+//ci.sh(`./ghr -t ${ci.env("GITHUB_TOKEN")} \
+//    -u ${ci.env("CIRCLE_PROJECT_USERNAME")} \
+//    -r ${ci.env("CIRCLE_PROJECT_REPONAME")} \
+//    -c ${ci.env("CIRCLE_SHA1")} \
+//    -replace ${ci.env("CIRCLE_TAG")} artifacts/`);
 

--- a/.circleci/ci/deploy-venia.js
+++ b/.circleci/ci/deploy-venia.js
@@ -20,7 +20,7 @@ ci.context();
 
 const releaseVersion = ci.sh(`mvn help:evaluate -Dexpression=project.version -q -DforceStdout`, true).toString().trim();
 const releaseArtifact = ci.sh(`mvn help:evaluate -Dexpression=project.artifactId -q -DforceStdout`, true).toString().trim();
-const mvnOpts = `-B -s /home/circleci/project/.circleci/settings.xml`
+const mvnOpts = `-B -s /home/circleci/repo/.circleci/settings.xml`
 
 ci.stage("Install GHR");
 ci.sh("mkdir -p tmp");

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,6 +245,7 @@ workflows:
             - build
           filters:
             branches:
-              ignore: /.*/
+              only: /issue\/CIF-2458/
+              # ignore: /.*/
             tags:
               only: /^venia(-classic)?-\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,11 @@ jobs:
             - maven-repo-v2-
       - run:
           name: Deploy Venia Sample Project to GitHub
-          command: node .circleci/ci/deploy-venia.js
+          command: |
+            echo $GPG_PRIVATE_KEY | base64 --decode | gpg --batch --import
+            node .circleci/ci/deploy-venia.js
+            rm -rf /home/circleci/.gnupg
+            rm -rf /home/circleci/.npmrc
 
 workflows:
   version: 2
@@ -235,6 +239,7 @@ workflows:
       - deploy-sample:
           context:
             - CIF Artifactory Cloud
+            - CIF Maven Central
             - CIF GitHub
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,6 @@ workflows:
             - build
           filters:
             branches:
-              only: /issue\/CIF-2458/
-              # ignore: /.*/
+              ignore: /.*/
             tags:
               only: /^venia(-classic)?-\d+\.\d+\.\d+$/

--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,7 @@ Bundle-DocURL:
                     <configuration>
                         <serverId>ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -433,7 +433,7 @@ Bundle-DocURL:
                     <configuration>
                         <serverId>ossrh</serverId>
                         <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
                     </configuration>
                 </plugin>
             </plugins>

--- a/ui.tests/pom.xml
+++ b/ui.tests/pom.xml
@@ -31,6 +31,7 @@
     <artifactId>aem-cif-guides-venia.ui.tests</artifactId>
     <name>Venia - UI Tests</name>
     <description>UI Tests for Venia</description>
+    <packaging>pom</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This enables the deployment of the Venia cloud artefacts to maven central to be reused by others. Classic artefacts were excluded to "save space" and execution time as there is no use case for them (yet). However they are still built and uploaded to github.

## Related Issue

CIF-2160

## How Has This Been Tested?

1) I deployed the last release tag to a staging repository and dropped it afterwards
1) I enabled deploy-sample job for this branch and run it once deploying a snapshot to ossrh

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.