### PR TITLE
CIF-2511: use target dependent assertions in integration tests

### DIFF
--- a/.circleci/ci/it-tests.js
+++ b/.circleci/ci/it-tests.js
@@ -54,6 +54,7 @@ try {
     let cifVersion = ci.sh('mvn help:evaluate -Dexpression=core.cif.components.version -q -DforceStdout', true);
     let wcmVersion = ci.sh('mvn help:evaluate -Dexpression=core.wcm.components.version -q -DforceStdout', true);
     let classifier = process.env.AEM;
+    let excludedCategory = classifier === 'classic' ? 'junit.category.IgnoreOn65' : 'junit.category.IgnoreOnCloud';
 
     ci.dir(qpPath, () => {
         // Connect to QP
@@ -105,7 +106,7 @@ try {
     // Run integration tests
     if (TYPE === 'integration') {
         ci.dir('it.tests', () => {
-            ci.sh(`mvn clean verify -U -B -Plocal`); // The -Plocal profile comes from the AEM archetype
+            ci.sh(`mvn clean verify -U -B -Dexclude.category=${excludedCategory} -Plocal`); // The -Plocal profile comes from the AEM archetype
         });
     }
     if (TYPE === 'selenium') {

--- a/it.tests/pom.xml
+++ b/it.tests/pom.xml
@@ -32,6 +32,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <!-- to be compatible with an un-parameterized build in CM, the default exclude category is set to IgnoreOnCloud -->
+        <exclude.category>junit.category.IgnoreOnCloud</exclude.category>
     </properties>
 
 
@@ -161,6 +163,7 @@
                                     <includes>
                                         <include>**/*IT.java</include>
                                     </includes>
+                                    <excludedGroups>${exclude.category}</excludedGroups>
                                 </configuration>
                             </execution>
                             <execution>

--- a/it.tests/src/main/java/com/venia/it/tests/CategoryPageIT.java
+++ b/it.tests/src/main/java/com/venia/it/tests/CategoryPageIT.java
@@ -17,6 +17,8 @@ package com.venia.it.tests;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.http.NameValuePair;
@@ -28,9 +30,13 @@ import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 import org.junit.Assert;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
 import com.venia.it.utils.Utils;
+import junit.category.IgnoreOn65;
+import junit.category.IgnoreOnCloud;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,8 +47,35 @@ public class CategoryPageIT extends CommerceTestBase {
     private static final String PRODUCTLIST_GALLERY_SELECTOR = PRODUCTLIST_SELECTOR + ".productcollection__root";
 
     @Test
-    public void testProductListPageWithSampleData() throws ClientException, IOException {
+    @Category({ IgnoreOnCloud.class })
+    public void testProductListPageWithSampleData65() throws ClientException, IOException {
         String pagePath = VENIA_CONTENT_US_EN_PRODUCTS_CATEGORY_PAGE + ".html/venia-bottoms/venia-pants.html";
+        testProductListPageWithSampleData(
+            pagePath,
+            ImmutableMap.of(
+                doc -> doc.select("title").first().html(), "Pants &amp; Shorts",
+                // on 6.5.8 the Sites SEO API is NOT available, and so the canonical link is created using the Externalizer and its
+                // default configuration
+                doc -> doc.select("link[rel=canonical]").first().attr("href"), "http://localhost:4502" + pagePath
+            ));
+    }
+
+    @Test
+    @Category({ IgnoreOn65.class })
+    public void testProductListPageWithSampleDataCloud() throws ClientException, IOException {
+        String pagePath = VENIA_CONTENT_US_EN_PRODUCTS_CATEGORY_PAGE + ".html/venia-bottoms/venia-pants.html";
+        testProductListPageWithSampleData(
+            pagePath,
+            ImmutableMap.of(
+                doc -> doc.select("title").first().html(), "Pants &amp; Shorts",
+                // on Cloud the Sites SEO API is available, but without any mappings configured the pagePath is returned as is as canonical
+                // link
+                doc -> doc.select("link[rel=canonical]").first().attr("href"), pagePath
+            ));
+    }
+
+    private void testProductListPageWithSampleData(String pagePath, Map<Function<Document, String>, String> expectations)
+        throws ClientException, IOException {
         SlingHttpResponse response = adminAuthor.doGet(pagePath, 200);
         Document doc = Jsoup.parse(response.getContent());
 
@@ -67,13 +100,9 @@ public class CategoryPageIT extends CommerceTestBase {
         assertEquals(6, elements.size());
 
         // Check the meta data
-        elements = doc.select("title");
-        assertEquals("Pants &amp; Shorts", elements.first().html());
-
-        // todo CIF-2511
-        // temporally disabled assertion because of failure related to CIF-2262 - test will be refactored later
-        // elements = doc.select("link[rel=canonical]");
-        // assertEquals("http://localhost:4502" + pagePath, elements.first().attr("href"));
+        for (Map.Entry<Function<Document, String>, String> expectation : expectations.entrySet()) {
+            assertEquals(expectation.getValue(), expectation.getKey().apply(doc));
+        }
 
         // Verify category gallery datalayer
         elements = doc.select(PRODUCTLIST_GALLERY_SELECTOR);
@@ -131,11 +160,11 @@ public class CategoryPageIT extends CommerceTestBase {
     @Test
     public void testCategoryNotFoundPage() throws ClientException {
         String pagePath = VENIA_CONTENT_US_EN_PRODUCTS_CATEGORY_PAGE + ".html/unknown-category.html";
-        List<NameValuePair> params = Collections.singletonList(new BasicNameValuePair("wcmmode","disabled"));
+        List<NameValuePair> params = Collections.singletonList(new BasicNameValuePair("wcmmode", "disabled"));
         SlingHttpResponse response = adminAuthor.doGet(pagePath, params, 404);
         Document doc = Jsoup.parse(response.getContent());
 
         Elements elements = doc.select(H1_SELECTOR);
-        assertEquals("Ruh-Roh! Page Not Found",elements.first().text());
+        assertEquals("Ruh-Roh! Page Not Found", elements.first().text());
     }
 }

--- a/it.tests/src/main/java/com/venia/it/tests/ProductPageIT.java
+++ b/it.tests/src/main/java/com/venia/it/tests/ProductPageIT.java
@@ -17,6 +17,8 @@ package com.venia.it.tests;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
@@ -26,9 +28,13 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.select.Elements;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableMap;
 import com.venia.it.utils.Utils;
+import junit.category.IgnoreOn65;
+import junit.category.IgnoreOnCloud;
 
 import static org.junit.Assert.assertEquals;
 
@@ -40,8 +46,35 @@ public class ProductPageIT extends CommerceTestBase {
     private static final String GROUPED_PRODUCTS_SELECTOR = PRODUCT_SELECTOR + ".productFullDetail__groupedProducts";
 
     @Test
-    public void testProductPageWithSampleData() throws ClientException, IOException {
+    @Category({ IgnoreOnCloud.class })
+    public void testProductPageWithSampleData65() throws ClientException, IOException {
         String pagePath = VENIA_CONTENT_US_EN_PRODUCTS_PRODUCT_PAGE + ".html/honora-wide-leg-pants.html";
+        testProductPageWithSampleData(
+            pagePath,
+            ImmutableMap.of(
+                doc -> doc.select("title").first().html(), "Honora Wide Leg Pants",
+                // on 6.5.8 the Sites SEO API is NOT available, and so the canonical link is created using the Externalizer and its
+                // default configuration
+                doc -> doc.select("link[rel=canonical]").first().attr("href"), "http://localhost:4502" + pagePath
+            ));
+    }
+
+    @Test
+    @Category({ IgnoreOn65.class })
+    public void testProductPageWithSampleDataCloud() throws ClientException, IOException {
+        String pagePath = VENIA_CONTENT_US_EN_PRODUCTS_PRODUCT_PAGE + ".html/honora-wide-leg-pants.html";
+        testProductPageWithSampleData(
+            pagePath,
+            ImmutableMap.of(
+                doc -> doc.select("title").first().html(), "Honora Wide Leg Pants",
+                // on Cloud the Sites SEO API is available, but without any mappings configured the pagePath is returned as is as canonical
+                // link
+                doc -> doc.select("link[rel=canonical]").first().attr("href"), pagePath
+            ));
+    }
+
+    private void testProductPageWithSampleData(String pagePath, Map<Function<Document, String>, String> expectations)
+        throws ClientException, IOException {
         SlingHttpResponse response = adminAuthor.doGet(pagePath, 200);
         Document doc = Jsoup.parse(response.getContent());
 
@@ -61,13 +94,9 @@ public class ProductPageIT extends CommerceTestBase {
         assertEquals(6, elements.size());
 
         // Check the meta data
-        elements = doc.select("title");
-        assertEquals("Honora Wide Leg Pants", elements.first().html());
-
-        // todo CIF-2511
-        // temporally disabled assertion because of failure related to CIF-2262 - test will be refactored later
-        // elements = doc.select("link[rel=canonical]");
-        // assertEquals("http://localhost:4502" + pagePath, elements.first().attr("href"));
+        for (Map.Entry<Function<Document, String>, String> expectation : expectations.entrySet()) {
+            assertEquals(expectation.getValue(), expectation.getKey().apply(doc));
+        }
 
         // Verify dataLayer attributes
         elements = doc.select(PRODUCT_DETAILS_SELECTOR);
@@ -118,11 +147,11 @@ public class ProductPageIT extends CommerceTestBase {
     @Test
     public void testProductNotFoundPage() throws ClientException {
         String pagePath = VENIA_CONTENT_US_EN_PRODUCTS_PRODUCT_PAGE + ".html/unknown-product.html";
-        List<NameValuePair> params = Collections.singletonList(new BasicNameValuePair("wcmmode","disabled"));
+        List<NameValuePair> params = Collections.singletonList(new BasicNameValuePair("wcmmode", "disabled"));
         SlingHttpResponse response = adminAuthor.doGet(pagePath, params, 404);
         Document doc = Jsoup.parse(response.getContent());
 
         Elements elements = doc.select(H1_SELECTOR);
-        assertEquals("Ruh-Roh! Page Not Found",elements.first().text());
+        assertEquals("Ruh-Roh! Page Not Found", elements.first().text());
     }
 }

--- a/it.tests/src/main/java/junit/category/IgnoreOn65.java
+++ b/it.tests/src/main/java/junit/category/IgnoreOn65.java
@@ -1,0 +1,18 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package junit.category;
+
+public interface IgnoreOn65 {}

--- a/it.tests/src/main/java/junit/category/IgnoreOnCloud.java
+++ b/it.tests/src/main/java/junit/category/IgnoreOnCloud.java
@@ -1,0 +1,18 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package junit.category;
+
+public interface IgnoreOnCloud {}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In this PR the assertions made to the page metadata for product and category pages were made dependent on the environment the test is executed again (6.5.8 or cloud). This is because the APIs used to generate the canonical link are different for on-prem 6.5.8 and cloud:
- 6.5.8 uses the Externalizer, creating a external author link as canonical url in the tests
- cloud uses the Sites SEO API without any sling mapping, returning the page path of products/categories as is

The implementation is done the same way as we run it already for the CIF Core Components, however we default to IngoreOnCloud as exclude category to not cause any issues for CM builds.

## Related Issue

CIF-2511, CIF-2262

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Locally, CI

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.