### PR TITLE
fix: remove `rm` command from i18n:extract-compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,6 @@ coverage/
 # UI Tests
 ui.tests/test-module/reports
 test-reports
+
+# Formatjs
+ui.frontend/i18n/__temp.json

--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -22,7 +22,7 @@
     "prettier:fix": "prettier --write '{src,test}/**/*.{js,css}' --config ./.prettierrc",
     "eslint:check": "eslint 'src/**/*.js'",
     "eslint:fix": "eslint --fix 'src/**/*.js'",
-    "i18n:extract-compile": "formatjs extract --out-file i18n/__temp.json 'src/**/*.js' && formatjs compile --ast --out-file i18n/en.json i18n/__temp.json && rm i18n/__temp.json"
+    "i18n:extract-compile": "formatjs extract --out-file i18n/__temp.json 'src/**/*.js' && formatjs compile --ast --out-file i18n/en.json i18n/__temp.json"
   },
   "devDependencies": {
     "@babel/core": "^7.3.4",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Removes the `rm` command from the `i18n:extract-compile` script in order to retain compatibility with non unix-like systems like windows.

## Related Issue

#238

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.