### PR TITLE
CIF-2114: Update Cloud Manager repositories for each release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,7 +206,7 @@ jobs:
             git config credential.helper '!f() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; f'
             git remote add downstream $GIT_REPO
             git fetch downstream
-            git switch -c tmp downstream/main
+            git checkout -b tmp downstream/main
             git merge $C_TAG
             git push tmp
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,12 +214,12 @@ workflows:
   version: 2
   build-and-release:
     jobs:
-      - build:
-          context:
-            - CIF Artifactory Cloud
-          filters:
-            tags:
-              only: /.*/
+#      - build:
+#          context:
+#            - CIF Artifactory Cloud
+#          filters:
+#            tags:
+#              only: /.*/
 #      - integration-test-655:
 #          context:
 #            - CIF Artifactory Cloud
@@ -266,9 +266,10 @@ workflows:
 #              only: /^venia(-classic)?-\d+\.\d+\.\d+$/
       - update-cm:
           context:
+            - CIF Artifactory Cloud
             - CIF CM Stage
-          requires:
-            - build
+#          requires:
+#            - build
 #          filters:
 #            branches:
 #              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -202,77 +202,76 @@ jobs:
       - run:
           name: Update CM Repository
           command: |
-            export C_TAG="venia-2021.12.01"
             git config credential.helper '!f() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; f'
             git remote add downstream $GIT_REPO
             git fetch downstream
             git checkout -b tmp downstream/main
-            git merge $C_TAG
+            git merge $CIRCLE_TAG
             git push downstream main
 
 workflows:
   version: 2
   build-and-release:
     jobs:
-#      - build:
-#          context:
-#            - CIF Artifactory Cloud
-#          filters:
-#            tags:
-#              only: /.*/
-#      - integration-test-655:
-#          context:
-#            - CIF Artifactory Cloud
-#          filters:
-#            tags:
-#              only: /.*/
-#          requires:
-#            - build
-#      - integration-test-cloudready-with-addon:
-#          context:
-#            - CIF Artifactory Cloud
-#          filters:
-#            tags:
-#              only: /.*/
-#          requires:
-#            - build
-#      - selenium-chrome-cloudready-with-addon:
-#          context:
-#            - CIF Artifactory Cloud
-#          filters:
-#            tags:
-#              only: /.*/
-#          requires:
-#            - build
-#      - selenium-chrome-655:
-#          context:
-#            - CIF Artifactory Cloud
-#          filters:
-#            tags:
-#              only: /.*/
-#          requires:
-#            - build
-#      - deploy-sample:
-#          context:
-#            - CIF Artifactory Cloud
-#            - CIF Maven Central
-#            - CIF GitHub
-#          requires:
-#            - build
-#          filters:
-#            branches:
-#              ignore: /.*/
-#            tags:
-#              only: /^venia(-classic)?-\d+\.\d+\.\d+$/
+      - build:
+          context:
+            - CIF Artifactory Cloud
+          filters:
+            tags:
+              only: /.*/
+      - integration-test-655:
+          context:
+            - CIF Artifactory Cloud
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build
+      - integration-test-cloudready-with-addon:
+          context:
+            - CIF Artifactory Cloud
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build
+      - selenium-chrome-cloudready-with-addon:
+          context:
+            - CIF Artifactory Cloud
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build
+      - selenium-chrome-655:
+          context:
+            - CIF Artifactory Cloud
+          filters:
+            tags:
+              only: /.*/
+          requires:
+            - build
+      - deploy-sample:
+          context:
+            - CIF Artifactory Cloud
+            - CIF Maven Central
+            - CIF GitHub
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^venia(-classic)?-\d+\.\d+\.\d+$/
       - update-cm:
           context:
             - CIF Artifactory Cloud
             - CIF CM Stage
-#          requires:
-#            - build
-#          filters:
-#            branches:
-#              ignore: /.*/
-#            tags:
-#              only: /^venia(-classic)?-\d+\.\d+\.\d+$/
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^venia(-classic)?-\d+\.\d+\.\d+$/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -194,6 +194,22 @@ jobs:
             rm -rf /home/circleci/.gnupg
             rm -rf /home/circleci/.npmrc
 
+  update-cm:
+    executor: cif_executor
+    working_directory: ~/repo
+    steps:
+      - checkout
+      - run:
+          name: Update CM Repository
+          command: |
+            export C_TAG="venia-2021.12.01"
+            git config credential.helper '!f() { sleep 1; echo "username=${GIT_USER}"; echo "password=${GIT_PASSWORD}"; }; f'
+            git remote add downstream $GIT_REPO
+            git fetch downstream
+            git switch -c tmp downstream/main
+            git merge $C_TAG
+            git push tmp
+
 workflows:
   version: 2
   build-and-release:
@@ -204,47 +220,58 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - integration-test-655:
+#      - integration-test-655:
+#          context:
+#            - CIF Artifactory Cloud
+#          filters:
+#            tags:
+#              only: /.*/
+#          requires:
+#            - build
+#      - integration-test-cloudready-with-addon:
+#          context:
+#            - CIF Artifactory Cloud
+#          filters:
+#            tags:
+#              only: /.*/
+#          requires:
+#            - build
+#      - selenium-chrome-cloudready-with-addon:
+#          context:
+#            - CIF Artifactory Cloud
+#          filters:
+#            tags:
+#              only: /.*/
+#          requires:
+#            - build
+#      - selenium-chrome-655:
+#          context:
+#            - CIF Artifactory Cloud
+#          filters:
+#            tags:
+#              only: /.*/
+#          requires:
+#            - build
+#      - deploy-sample:
+#          context:
+#            - CIF Artifactory Cloud
+#            - CIF Maven Central
+#            - CIF GitHub
+#          requires:
+#            - build
+#          filters:
+#            branches:
+#              ignore: /.*/
+#            tags:
+#              only: /^venia(-classic)?-\d+\.\d+\.\d+$/
+      - update-cm:
           context:
-            - CIF Artifactory Cloud
-          filters:
-            tags:
-              only: /.*/
+            - CIF CM Stage
           requires:
             - build
-      - integration-test-cloudready-with-addon:
-          context:
-            - CIF Artifactory Cloud
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - build
-      - selenium-chrome-cloudready-with-addon:
-          context:
-            - CIF Artifactory Cloud
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - build
-      - selenium-chrome-655:
-          context:
-            - CIF Artifactory Cloud
-          filters:
-            tags:
-              only: /.*/
-          requires:
-            - build
-      - deploy-sample:
-          context:
-            - CIF Artifactory Cloud
-            - CIF Maven Central
-            - CIF GitHub
-          requires:
-            - build
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^venia(-classic)?-\d+\.\d+\.\d+$/
+#          filters:
+#            branches:
+#              ignore: /.*/
+#            tags:
+#              only: /^venia(-classic)?-\d+\.\d+\.\d+$/
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,7 +208,7 @@ jobs:
             git fetch downstream
             git checkout -b tmp downstream/main
             git merge $C_TAG
-            git push tmp
+            git push downstream main
 
 workflows:
   version: 2


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We want to keep our internal staging environment(s) up to date with the latest Venia release. This change adds another step to the CI workflow which updates the CM repository with the latest Venia release tag.

## Related Issue

CIF-2114

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Some test runs on CircleCI to validate the script execution using the latest release tag. Note: the expected outcome would be a rejected push as we already merged venia-2021-12-01 before.

https://app.circleci.com/pipelines/github/adobe/aem-cif-guides-venia/1148/workflows/702fb05e-bb57-494d-b279-30ed0b78db00/jobs/5253

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.