### PR TITLE
CIF-2646: move /content/venia => / mapping to etc/map

### DIFF
--- a/ui.config/src/main/content/jcr_root/apps/venia/osgiconfig/config.publish/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.cfg.json
+++ b/ui.config/src/main/content/jcr_root/apps/venia/osgiconfig/config.publish/org.apache.sling.jcr.resource.internal.JcrResourceResolverFactoryImpl.cfg.json
@@ -1,5 +1,0 @@
-{
-  "resource.resolver.mapping": [
-    "/content/venia/&lt;/", "/:/"
-  ]
-}

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/.content.xml
@@ -1,3 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
-    jcr:primaryType="sling:Folder"/>
+    jcr:primaryType="sling:Folder"
+    jcr:mixinTypes="[sling:MappingSpec]"
+    sling:internalRedirect="[/,/content/venia]"/>

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/category-page/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/category-page/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/$1/$2/products/category-page.html/$3"
-    sling:match="content/venia/([a-z]{2})/([a-z]{2})/c/(.+)" />
+    sling:match="([a-z]{2})/([a-z]{2})/c/(.+)" />

--- a/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/product-page/.content.xml
+++ b/ui.content/src/main/content/jcr_root/etc/map.publish/https/hostname.adobeaemcloud.com/product-page/.content.xml
@@ -2,4 +2,4 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
     jcr:primaryType="sling:Mapping"
     sling:internalRedirect="/content/venia/$1/$2/products/product-page.html/$3"
-    sling:match="content/venia/([a-z]{2})/([a-z]{2})/p/([^\\.]+)" />
+    sling:match="([a-z]{2})/([a-z]{2})/p/([^\\.]+)" />


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Canonical link generation does not fully work on Cloud Service. We only have mappings for product/category pages in etc/map. This change moves the path mapping for all pages also to etc/map in order to generate absolute urls for content as well. 

## Related Issue

CIF-1675, 
CIF-2646

## Motivation and Context

Sitemaps, canonical links

## How Has This Been Tested?

locally 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.