### PR TITLE
CIF-2678 - Styling is broken on catalog page in Venia and archetype projects

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/catalogpage/customheaderlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/catalogpage/customheaderlibs.html
@@ -13,9 +13,9 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */-->
-<sly data-sly-use.clientLib="/libs/granite/sightly/templates/clientlib.html">
-    <sly data-sly-call="${clientlib.css @ categories='venia.base'}">
-    <sly data-sly-call="${clientlib.css @ categories='venia.cif'}" />
+<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
+    <sly data-sly-call="${clientlib.css @ categories='venia.base'}"/>
+    <sly data-sly-call="${clientlib.css @ categories='venia.cif'}"/>
 </sly>
 
 <sly data-sly-resource="${'contexthub' @ resourceType='granite/contexthub/components/contexthub'}"/>


### PR DESCRIPTION
 * fixed HTL syntax in catalogpage customheaderlibs.html

## Related Issue

CIF-2678


## How Has This Been Tested?

Manually.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.