### PR TITLE
CIF-1938: add ui tests for catalog page status bar

### DIFF
--- a/ui.tests/test-module/specs/venia/statusbar.js
+++ b/ui.tests/test-module/specs/venia/statusbar.js
@@ -1,0 +1,65 @@
+/*
+ *  Copyright 2021 Adobe Systems Incorporated
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+const config = require('../../lib/config');
+const { OnboardingDialogHandler } = require('../../lib/commons');
+
+describe('Catalog Page Status', function () {
+    const editor_page = `${config.aem.author.base_url}/editor.html`;
+    const product_page = '/content/venia/us/en/products/product-page';
+    const specific_page = '/content/venia/us/en/products/category-page/shop-the-look.html/shop-the-look';
+
+    let onboardingHdler;
+
+    this.retries(2);
+
+    before(() => {
+        // Set window size to desktop
+        browser.setWindowSize(1280, 960);
+
+        // AEM Login
+        browser.AEMForceLogout();
+        browser.url(config.aem.author.base_url);
+        browser.AEMLogin(config.aem.author.username, config.aem.author.password);
+
+        // Enable helper to handle onboarding dialog popup
+        onboardingHdler = new OnboardingDialogHandler(browser);
+        onboardingHdler.enable();
+    });
+
+    after(function () {
+        // Disable helper to handle onboarding dialog popup
+        onboardingHdler.disable();
+    });
+
+    it('is shown on template pages', () => {
+        browser.url(`${editor_page}${product_page}.html`);
+        browser.AEMEditorLoaded();
+
+        expect($('coral-alert-header=Venia Demo Store - Product page')).toBeDisplayed();
+        expect($('a[data-status-action-id="open-template-page"]')).not.toBeDisplayed();
+    });
+
+    it('is shown on specific pages', () => {
+        browser.url(`${editor_page}${specific_page}.html`);
+        browser.AEMEditorLoaded();
+
+        expect($('coral-alert-header=Shop the look')).toBeDisplayed();
+
+        const openTemplatePageButton = $('a[data-status-action-id="open-template-page"]');
+        expect(openTemplatePageButton).toBeClickable();
+    });
+});

--- a/ui.tests/test-module/specs/venia/statusbar.js
+++ b/ui.tests/test-module/specs/venia/statusbar.js
@@ -53,7 +53,8 @@ describe('Catalog Page Status', function () {
         expect($('a[data-status-action-id="open-template-page"]')).not.toBeDisplayed();
     });
 
-    it('is shown on specific pages', () => {
+    // TODO: CIF-2734 enable the test after part of the next addon release
+    it.skip('is shown on specific pages', () => {
         browser.url(`${editor_page}${specific_page}.html`);
         browser.AEMEditorLoaded();
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds ui.tests to verify the catalog page status is shown on template pages and catalog pages. 

The test `Catalog Page Status is shown on specific pages` requires an AddOn release and so is for now disabled.

## Related Issue

CIF-1938

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.