### PR TITLE
CIF-2757 - Add UI tests for tracking annotations for product and category filters in page properties

### DIFF
--- a/ui.tests/test-module/specs/venia/commerce-page-dialogs.js
+++ b/ui.tests/test-module/specs/venia/commerce-page-dialogs.js
@@ -97,7 +97,7 @@ describe('Commerce Page Component Dialog', function () {
         const categoryField = fields[0].$('category-field');
         expect(categoryField).toExist();
         expect(categoryField).toHaveAttribute('trackingelement', 'category filter');
-        expect(categoryField).toHaveAttribute('trackingfeature', 'aem:cif:specificcatalogtemplate');
+        expect(categoryField).toHaveAttribute('trackingfeature', 'aem:cif:specificcategorytemplate');
         expect(fields[0].$('coral-taglist[name="./selectorFilter"]')).toExist();
         expect(fields[1].$('coral-checkbox')).toExist();
         expect(fields[1].$('input[name="./includesSubCategories"]')).toExist();
@@ -124,14 +124,14 @@ describe('Commerce Page Component Dialog', function () {
         const productField = fields[0].$('product-field');
         expect(productField).toExist();
         expect(productField).toHaveAttribute('trackingelement', 'product filter');
-        expect(productField).toHaveAttribute('trackingfeature', 'aem:cif:specificcatalogtemplate');
+        expect(productField).toHaveAttribute('trackingfeature', 'aem:cif:specificproducttemplate');
 
         expect(fields[0].$('product-field')).toExist();
         expect(fields[0].$('coral-taglist[name="./selectorFilter"]')).toExist();
         const categoryField = fields[1].$('category-field');
         expect(categoryField).toExist();
         expect(categoryField).toHaveAttribute('trackingelement', 'category filter');
-        expect(categoryField).toHaveAttribute('trackingfeature', 'aem:cif:specificcatalogtemplate');
+        expect(categoryField).toHaveAttribute('trackingfeature', 'aem:cif:specificproducttemplate');
         expect(fields[1].$('coral-taglist[name="./useForCategories"]')).toExist();
         expect(fields[2].$('coral-checkbox')).toExist();
         expect(fields[2].$('input[name="./includesSubCategories"]')).toExist();

--- a/ui.tests/test-module/specs/venia/commerce-page-dialogs.js
+++ b/ui.tests/test-module/specs/venia/commerce-page-dialogs.js
@@ -94,7 +94,10 @@ describe('Commerce Page Component Dialog', function () {
 
         // check fields
         expect(fields.length).toEqual(2);
-        expect(fields[0].$('category-field')).toExist();
+        const categoryField = fields[0].$('category-field');
+        expect(categoryField).toExist();
+        expect(categoryField).toHaveAttribute('trackingelement', 'category filter');
+        expect(categoryField).toHaveAttribute('trackingfeature', 'aem:cif:specificcatalogtemplate');
         expect(fields[0].$('coral-taglist[name="./selectorFilter"]')).toExist();
         expect(fields[1].$('coral-checkbox')).toExist();
         expect(fields[1].$('input[name="./includesSubCategories"]')).toExist();
@@ -118,9 +121,17 @@ describe('Commerce Page Component Dialog', function () {
 
         // check fields
         expect(fields.length).toEqual(3);
+        const productField = fields[0].$('product-field');
+        expect(productField).toExist();
+        expect(productField).toHaveAttribute('trackingelement', 'product filter');
+        expect(productField).toHaveAttribute('trackingfeature', 'aem:cif:specificcatalogtemplate');
+
         expect(fields[0].$('product-field')).toExist();
         expect(fields[0].$('coral-taglist[name="./selectorFilter"]')).toExist();
-        expect(fields[1].$('category-field')).toExist();
+        const categoryField = fields[1].$('category-field');
+        expect(categoryField).toExist();
+        expect(categoryField).toHaveAttribute('trackingelement', 'category filter');
+        expect(categoryField).toHaveAttribute('trackingfeature', 'aem:cif:specificcatalogtemplate');
         expect(fields[1].$('coral-taglist[name="./useForCategories"]')).toExist();
         expect(fields[2].$('coral-checkbox')).toExist();
         expect(fields[2].$('input[name="./includesSubCategories"]')).toExist();


### PR DESCRIPTION
## Description

* Added E2E tests for https://github.com/adobe/aem-core-cif-components/pull/885
* Tests require changes from the add-on, so they might fail until the new release is out.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.