### PR TITLE
CIF-2302: load cif and base clientlibs async

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/clientlibs/clientlib-cif/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/clientlibs/clientlib-cif/.content.xml
@@ -5,4 +5,4 @@
     cssProcessor="[default:none,min:none]"
     jsProcessor="[default:none,min:none]"
     categories="[venia.cif]" 
-    embed="[core.cif.components.product.v1,core.cif.components.productcarousel.v1,core.cif.components.productcollection.v2,core.cif.components.productteaser.v1,core.cif.components.searchbar.v2,core.cif.components.header.v1,core.cif.components.carousel.v1,core.cif.components.categorycarousel.v1,core.cif.components.featuredcategorylist.v1,core.cif.components.storefront-events.v1,core.cif.components.extensions.product-recs.storefront-events-collector.v1]" />
+    embed="[core.cif.components.common,core.cif.components.product.v1,core.cif.components.productcarousel.v1,core.cif.components.productcollection.v2,core.cif.components.productteaser.v1,core.cif.components.searchbar.v2,core.cif.components.header.v1,core.cif.components.carousel.v1,core.cif.components.categorycarousel.v1,core.cif.components.featuredcategorylist.v1,core.cif.components.storefront-events.v1,core.cif.components.extensions.product-recs.storefront-events-collector.v1]" />

--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/catalogpage/customfooterlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/catalogpage/customfooterlibs.html
@@ -13,8 +13,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */-->
-<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
-    <sly data-sly-call="${clientlib.js @ categories='venia.base'}"/>
-    <sly data-sly-call="${clientlib.js @ categories='venia.cif'}" />
+<sly data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
+    <sly data-sly-call="${clientlib.js @ categories='venia.base', async=true}"/>
+    <sly data-sly-call="${clientlib.js @ categories='venia.cif, async=true'}" />
 </sly>
 

--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/catalogpage/customheaderlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/catalogpage/customheaderlibs.html
@@ -13,7 +13,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */-->
-<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
+<sly data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
     <sly data-sly-call="${clientlib.css @ categories='venia.base'}"/>
     <sly data-sly-call="${clientlib.css @ categories='venia.cif'}"/>
 </sly>

--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/page/customfooterlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/page/customfooterlibs.html
@@ -13,8 +13,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */-->
-<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
-    <sly data-sly-call="${clientlib.js @ categories='venia.base'}"/>
-    <sly data-sly-call="${clientlib.js @ categories='venia.cif'}" />
+<sly data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
+    <sly data-sly-call="${clientlib.js @ categories='venia.base', async=true}"/>
+    <sly data-sly-call="${clientlib.js @ categories='venia.cif', async=true}" />
 </sly>
 

--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/page/customheaderlibs.html
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/page/customheaderlibs.html
@@ -13,7 +13,7 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 */-->
-<sly data-sly-use.clientlib="/libs/granite/sightly/templates/clientlib.html">
+<sly data-sly-use.clientlib="core/wcm/components/commons/v1/templates/clientlib.html">
     <sly data-sly-call="${clientlib.css @ categories='venia.base,venia.cif'}"/>
 </sly>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change adds support for loading the javascript clientlibs `async`. To achieve this the `core.cif.components.common` clientlib is required to be embedded together with the component clientlibs. 

## Related Issue

CIF-2302

## Motivation and Context

Core Web Vitals

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.