### PR TITLE
CIF-2919: add gql client cache configuration for cloud

### DIFF
--- a/all/pom.xml
+++ b/all/pom.xml
@@ -54,6 +54,12 @@
                     <properties>
                         <cloudManagerTarget>all</cloudManagerTarget>
                     </properties>
+                    <repositoryStructurePackages>
+                        <repositoryStructurePackage>
+                            <groupId>com.adobe.aem.guides</groupId>
+                            <artifactId>aem-cif-guides-venia.ui.apps.structure</artifactId>
+                        </repositoryStructurePackage>
+                    </repositoryStructurePackages>
                     <embeddeds>
                         <embedded>
                             <groupId>com.adobe.aem.guides</groupId>
@@ -199,6 +205,12 @@
         <dependency>
             <groupId>com.adobe.aem.guides</groupId>
             <artifactId>aem-cif-guides-venia.ui.apps</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+        </dependency>
+        <dependency>
+            <groupId>com.adobe.aem.guides</groupId>
+            <artifactId>aem-cif-guides-venia.ui.apps.structure</artifactId>
             <version>${project.version}</version>
             <type>zip</type>
         </dependency>

--- a/all/src/main/content/META-INF/vault/filter.xml
+++ b/all/src/main/content/META-INF/vault/filter.xml
@@ -17,4 +17,5 @@
 <workspaceFilter version="1.0">
     <filter root="/apps/venia-packages"/>
     <filter root="/apps/venia-vendor-packages"/>
+    <filter root="/apps/venia/osgiconfig-cloud"/>
 </workspaceFilter>

--- a/all/src/main/content/jcr_root/apps/venia/osgiconfig-cloud/config.author/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl~venia.cfg.json
+++ b/all/src/main/content/jcr_root/apps/venia/osgiconfig-cloud/config.author/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl~venia.cfg.json
@@ -1,0 +1,17 @@
+{
+  "identifier": "default",
+  "service.ranking": 5,
+  "url": "$[env:COMMERCE_ENDPOINT;default=]",
+  "acceptSelfSignedCertificates": false,
+  "httpMethod": "GET",
+  "httpHeaders": ["$[secret:COMMERCE_AUTH_HEADER;default=]"],
+  "maxHttpConnections": 20,
+  "connectionTimeout": 5000,
+  "requestPoolTimeout": 2000,
+  "socketTimeout": 5000,
+  "cacheConfigurations": [
+    "venia/components/commerce/navigation:true:5:300",
+    "com.adobe.cq.commerce.core.search.services.SearchFilterService:true:10:300",
+    "venia/components/commerce/breadcrumb:true:1000:300"
+  ]
+}

--- a/all/src/main/content/jcr_root/apps/venia/osgiconfig-cloud/config.publish/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl~venia.cfg.json
+++ b/all/src/main/content/jcr_root/apps/venia/osgiconfig-cloud/config.publish/com.adobe.cq.commerce.graphql.client.impl.GraphqlClientImpl~venia.cfg.json
@@ -1,0 +1,16 @@
+{
+  "identifier": "default",
+  "service.ranking": 5,
+  "url": "$[env:COMMERCE_ENDPOINT;default=]",
+  "acceptSelfSignedCertificates": false,
+  "httpMethod": "GET",
+  "maxHttpConnections": 20,
+  "connectionTimeout": 5000,
+  "requestPoolTimeout": 2000,
+  "socketTimeout": 5000,
+  "cacheConfigurations": [
+    "venia/components/commerce/navigation:true:5:300",
+    "com.adobe.cq.commerce.core.search.services.SearchFilterService:true:10:300",
+    "venia/components/commerce/breadcrumb:true:1000:300"
+  ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change adds the GraphqlClient configuration that we already had as example with caching enabled for classic, to AEMaaCS.  

The configuration can be considered as a recommendation and starting point.

The configuration is added to the cloud container package `all`, in order to not introduce another artefact to the reactor. Currently the `ui.config` and `classic/ui.config` packages are both deployed by the `classic/all` container.  

## Related Issue

CIF-2919

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.