### PR TITLE
CIF-2895 - Add example for product filter hook

### DIFF
--- a/core/src/main/java/com/venia/core/models/commerce/MyProductTeaserImpl.java
+++ b/core/src/main/java/com/venia/core/models/commerce/MyProductTeaserImpl.java
@@ -26,7 +26,8 @@ import com.adobe.cq.commerce.core.components.models.common.Price;
 import com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductRetriever;
 
-import com.adobe.cq.commerce.magento.graphql.FilterEqualTypeInput;
+import com.adobe.cq.commerce.magento.graphql.FilterRangeTypeInput;
+
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Model;
@@ -65,8 +66,9 @@ public class MyProductTeaserImpl implements MyProductTeaser {
             // Alternatively you can also return your own instance of ProductAttributeFilterInput to
             // completely replace the filter.
             productRetriever.extendProductFilterWith(f -> f
-                .setCustomFilter("my-attribute", new FilterEqualTypeInput()
-                    .setEq("my-value")));
+                .setPrice(new FilterRangeTypeInput()
+                    .setFrom("0")
+                    .setTo("50000")));
         }
     }
 

--- a/core/src/main/java/com/venia/core/models/commerce/MyProductTeaserImpl.java
+++ b/core/src/main/java/com/venia/core/models/commerce/MyProductTeaserImpl.java
@@ -61,13 +61,12 @@ public class MyProductTeaserImpl implements MyProductTeaser {
             // as you try to access any product property.
             productRetriever.extendProductQueryWith(p -> p.createdAt());
 
-            // Replace the product attribute filter of the product query by passing your own to the ProductRetriever.
-            // In comparison to extending product queries, the filter will not be extended but completely replaced.
-            // For this purpose, the lambda function will receive the product identifier and the instance of
-            // ProductAttributeFilterInput instance.
-            productRetriever.replaceProductFilterWith((identifier, f) -> f
-                    .setSku(new FilterEqualTypeInput().setEq(identifier))
-                    .setCustomFilter("eco-friendly", new FilterEqualTypeInput().setEq("yes")));
+            // Extend the product attribute query by passing a partial filter to the ProductRetriever.
+            // Alternatively you can also return your own instance of ProductAttributeFilterInput to
+            // completely replace the filter.
+            productRetriever.extendProductFilterWith(f -> f
+                .setCustomFilter("my-attribute", new FilterEqualTypeInput()
+                    .setEq("my-value")));
         }
     }
 

--- a/core/src/main/java/com/venia/core/models/commerce/MyProductTeaserImpl.java
+++ b/core/src/main/java/com/venia/core/models/commerce/MyProductTeaserImpl.java
@@ -26,6 +26,7 @@ import com.adobe.cq.commerce.core.components.models.common.Price;
 import com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductRetriever;
 
+import com.adobe.cq.commerce.magento.graphql.FilterEqualTypeInput;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Model;
@@ -59,6 +60,14 @@ public class MyProductTeaserImpl implements MyProductTeaser {
             // automatically take care of executing your query as soon
             // as you try to access any product property.
             productRetriever.extendProductQueryWith(p -> p.createdAt());
+
+            // Replace the product attribute filter of the product query by passing your own to the ProductRetriever.
+            // In comparison to extending product queries, the filter will not be extended but completely replaced.
+            // For this purpose, the lambda function will receive the product identifier and the instance of
+            // ProductAttributeFilterInput instance.
+            productRetriever.replaceProductFilterWith((identifier, f) -> f
+                    .setSku(new FilterEqualTypeInput().setEq(identifier))
+                    .setCustomFilter("eco-friendly", new FilterEqualTypeInput().setEq("yes")));
         }
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <core.wcm.components.version>2.18.6</core.wcm.components.version>
         <core.cif.components.version>2.10.1-SNAPSHOT</core.cif.components.version>
         <graphql.client.version>1.7.10</graphql.client.version>
-        <magento.graphql.version>9.1.0-magento242ee-SNAPSHOT</magento.graphql.version>
+        <magento.graphql.version>9.1.0-magento242ee</magento.graphql.version>
         <bnd.version>5.1.2</bnd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <core.wcm.components.version>2.18.6</core.wcm.components.version>
         <core.cif.components.version>2.10.1-SNAPSHOT</core.cif.components.version>
         <graphql.client.version>1.7.10</graphql.client.version>
-        <magento.graphql.version>11.0.1-magento244ee-SNAPSHOT</magento.graphql.version>
+        <magento.graphql.version>9.1.0-magento242ee-SNAPSHOT</magento.graphql.version>
         <bnd.version>5.1.2</bnd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
         <core.wcm.components.version>2.18.6</core.wcm.components.version>
         <core.cif.components.version>2.10.1-SNAPSHOT</core.cif.components.version>
         <graphql.client.version>1.7.10</graphql.client.version>
-        <magento.graphql.version>9.0.0-magento242ee</magento.graphql.version>
+        <magento.graphql.version>11.0.1-magento244ee-SNAPSHOT</magento.graphql.version>
         <bnd.version>5.1.2</bnd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

* Added example of how to extend the product filter via retriever in `MyProductTeaser`. The added filter does not have any impact when using the Venia product catalog.

Requires a release of https://github.com/adobe/commerce-cif-magento-graphql/pull/29 before it can be merged.

## Related Issue

See 
* https://github.com/adobe/commerce-cif-magento-graphql/pull/27
* https://github.com/adobe/aem-core-cif-components/pull/938

## How Has This Been Tested?

Manually tested.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.