### PR TITLE
SITES-6859: add open in new tab labels for screen readers

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/venia/clientlibs/clientlib-cif/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/clientlibs/clientlib-cif/.content.xml
@@ -5,4 +5,4 @@
     cssProcessor="[default:none,min:none]"
     jsProcessor="[default:none,min:none]"
     categories="[venia.cif]" 
-    embed="[core.cif.components.common,core.cif.components.product.v3,core.cif.components.productcarousel.v1,core.cif.components.productcollection.v2,core.cif.components.productteaser.v1,core.cif.components.searchbar.v2,core.cif.components.header.v1,core.cif.components.carousel.v1,core.cif.components.categorycarousel.v1,core.cif.components.featuredcategorylist.v1,core.cif.components.storefront-events.v1,core.cif.components.extensions.product-recs.storefront-events-collector.v1]" />
+    embed="[core.cif.components.common,core.cif.components.product.v3,core.cif.components.productcarousel.v1,core.cif.components.productcollection.v2,core.cif.components.productteaser.v1,core.cif.components.searchbar.v2,core.cif.components.header.v1,core.cif.components.carousel.v1,core.cif.components.categorycarousel.v1,core.cif.components.featuredcategorylist.v1,core.cif.components.storefront-events.v1,core.cif.components.extensions.product-recs.storefront-events-collector.v1,core.wcm.components.commons.site.link]" />

--- a/ui.frontend/src/main/site/_base.scss
+++ b/ui.frontend/src/main/site/_base.scss
@@ -88,3 +88,11 @@ button:disabled {
     cursor: default;
     touch-action: none;
 }
+
+.cmp-link__screen-reader-only {
+    position: absolute;
+    width: 1px;
+    clip: rect(0 0 0 0);
+    overflow: hidden;
+    white-space: nowrap;
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds the links clientlib to Venia which renders a "(opens in new tab)" text to each taget="_blank" link for screen readers.

## Related Issue

SITES-6859

## Motivation and Context

Show the latest features wrt accessibility from the WCM Core Components.

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [X] I ran all tests locally and they pass.