### PR TITLE
CIF-2946: add cif specific composite status type for editor to classic

### DIFF
--- a/classic/ui.config/src/main/content/jcr_root/apps/venia/osgiconfig-classic/config.author/com.adobe.granite.resourcestatus.impl.CompositeStatusType~editor.config.cfg.json
+++ b/classic/ui.config/src/main/content/jcr_root/apps/venia/osgiconfig-classic/config.author/com.adobe.granite.resourcestatus.impl.CompositeStatusType~editor.config.cfg.json
@@ -1,0 +1,8 @@
+{
+    "name": "editor",
+    "types": [
+        "catalog-page",
+        "workflow",
+        "launches"
+    ]
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Added the Composite Status Type for editor that was moved to the CS quickstart to Venia for classic. 

## Related Issue

https://github.com/adobe/aem-core-cif-components/pull/951
https://github.com/adobe/aem-cif-guides-venia/pull/264

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Locally, the configuration has a higher priority of the ootb one from /libs

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [X] All unit tests pass on CircleCi.
- [ ] I ran all tests locally and they pass.