### PR TITLE
CIF-2986: fix typo in client-side price loading flag

### DIFF
--- a/ui.content/src/main/content/jcr_root/conf/venia/settings/cloudconfigs/commerce/.content.xml
+++ b/ui.content/src/main/content/jcr_root/conf/venia/settings/cloudconfigs/commerce/.content.xml
@@ -11,5 +11,5 @@
         magentoRootCategoryId="Mg=="
         magentoStore="default"
         enableUIDSupport="true"
-        enableClientSidePriceLoadin="{Boolean}true"/>
+        enableClientSidePriceLoading="{Boolean}true"/>
 </jcr:root>


### PR DESCRIPTION
Fix the typo in the "Enable client-side price loading" cloud configuration flag.

<!--- Provide a general summary of your changes in the Title above -->

## Description

Client-side price loading is off in CIF Venia guides. [A typo in commerce cloud config](https://github.com/adobe/aem-cif-guides-venia/blob/main/ui.content/src/main/content/jcr_root/conf/venia/settings/cloudconfigs/commerce/.content.xml#L14) resulted in cloud config "Enable client-side price loading" flag being turned off by default.

## Related Issue

CIF-2986

## Motivation and Context

Product prices should be fetched client-side by default to keep the original behavior. "Enable client-side price loading"  commerce cloud config flag should be enabled by default.

## How Has This Been Tested?

1. Go to a Venia commerce cloud config, and see the "Enable client-side price loading" enabled.
2. Open a page with a product component, and in the browser network tab, there is an additional client-side request to fetch the price.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes and the overall coverage did not decrease.
- [ ] All unit tests pass on CircleCi.
- [x] I ran all tests locally and they pass.