### PR TITLE
feat(productteaser): Low Stock Badge — author-configurable inventory badge

### DIFF
--- a/core/src/main/java/com/venia/core/models/commerce/MyProductTeaser.java
+++ b/core/src/main/java/com/venia/core/models/commerce/MyProductTeaser.java
@@ -22,4 +22,16 @@ public interface MyProductTeaser extends ProductTeaser {
     // Extend the existing interface with the additional properties which you
     // want to expose to the HTL template.
     public Boolean isShowBadge();
+
+    /**
+     * Returns {@code true} when the product's stock_status is IN_STOCK and
+     * only_x_left_in_stock is &gt; 0 and &lt;= the author-configured threshold.
+     */
+    public Boolean isLowStock();
+
+    /**
+     * Returns the remaining quantity as a display string (e.g. "Only 3 left!"),
+     * or {@code null} when the product is not in a low-stock state.
+     */
+    public String getLowStockMessage();
 }

--- a/core/src/main/java/com/venia/core/models/commerce/MyProductTeaserImpl.java
+++ b/core/src/main/java/com/venia/core/models/commerce/MyProductTeaserImpl.java
@@ -27,8 +27,12 @@ import com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductRetriever;
 
 import com.adobe.cq.commerce.magento.graphql.FilterRangeTypeInput;
+import com.adobe.cq.commerce.magento.graphql.ProductInterface;
+import com.adobe.cq.commerce.magento.graphql.ProductStockStatus;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.sling.api.resource.ValueMap;
 import org.apache.sling.models.annotations.Model;
 import org.apache.sling.models.annotations.Via;
@@ -41,6 +45,7 @@ public class MyProductTeaserImpl implements MyProductTeaser {
 
     protected static final String RESOURCE_TYPE = "venia/components/commerce/productteaser";
 
+    private static final Logger LOG = LoggerFactory.getLogger(MyProductTeaserImpl.class);
     private static DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
     @Self
@@ -61,6 +66,9 @@ public class MyProductTeaserImpl implements MyProductTeaser {
             // automatically take care of executing your query as soon
             // as you try to access any product property.
             productRetriever.extendProductQueryWith(p -> p.createdAt());
+            productRetriever.extendProductQueryWith(p -> p
+                .stockStatus()
+                .onlyXLeftInStock());
 
             // Extend the product attribute query by passing a partial filter to the ProductRetriever.
             // Alternatively you can also return your own instance of ProductAttributeFilterInput to
@@ -89,6 +97,41 @@ public class MyProductTeaserImpl implements MyProductTeaser {
             }
         }
         return false;
+    }
+
+    @Override
+    public Boolean isLowStock() {
+        if (!properties.get("lowStockEnabled", false) || productRetriever == null) {
+            return false;
+        }
+        try {
+            ProductInterface product = productRetriever.fetchProduct();
+            if (product == null || product.getStockStatus() != ProductStockStatus.IN_STOCK) {
+                return false;
+            }
+            Double onlyXLeft = product.getOnlyXLeftInStock();
+            if (onlyXLeft == null) {
+                return false;
+            }
+            int threshold = properties.get("lowStockThreshold", 5);
+            return onlyXLeft > 0 && onlyXLeft <= threshold;
+        } catch (Exception e) {
+            LOG.warn("Unable to determine low stock status for product teaser", e);
+            return false;
+        }
+    }
+
+    @Override
+    public String getLowStockMessage() {
+        if (!isLowStock()) {
+            return null;
+        }
+        String customText = properties.get("lowStockText", "");
+        if (!customText.isEmpty()) {
+            return customText;
+        }
+        int qty = productRetriever.fetchProduct().getOnlyXLeftInStock().intValue();
+        return "Only " + qty + " left!";
     }
 
     @Override

--- a/core/src/test/java/com/venia/core/models/commerce/MyProductTeaserImplTest.java
+++ b/core/src/test/java/com/venia/core/models/commerce/MyProductTeaserImplTest.java
@@ -21,6 +21,7 @@ import com.adobe.cq.commerce.core.components.models.productteaser.ProductTeaser;
 import com.adobe.cq.commerce.core.components.models.retriever.AbstractProductRetriever;
 import com.adobe.cq.commerce.core.components.services.urls.UrlProvider;
 import com.adobe.cq.commerce.magento.graphql.ProductInterface;
+import com.adobe.cq.commerce.magento.graphql.ProductStockStatus;
 import com.adobe.cq.wcm.core.components.models.Component;
 import com.day.cq.wcm.api.Page;
 import com.day.cq.wcm.scripting.WCMBindingsConstants;
@@ -58,6 +59,9 @@ class MyProductTeaserImplTest {
     private static final String PRODUCTTEASER_BADGE_FALSE = "productteaser-badge-false";
     private static final String PRODUCTTEASER_BADGE_TRUE_NO_AGE = "productteaser-badge-true-no-age";
     private static final String PRODUCTTEASER_BADGE_TRUE_WITH_AGE = "productteaser-badge-true-with-age";
+    private static final String PRODUCTTEASER_LOW_STOCK_DISABLED = "productteaser-low-stock-disabled";
+    private static final String PRODUCTTEASER_LOW_STOCK_IN_STOCK = "productteaser-low-stock-in-stock";
+    private static final String PRODUCTTEASER_LOW_STOCK_CUSTOM_TEXT = "productteaser-low-stock-custom-text";
 
     public final AemContext context = new AemContext(ResourceResolverType.JCR_MOCK);
 
@@ -84,8 +88,24 @@ class MyProductTeaserImplTest {
         createResource(page, PRODUCTTEASER_BADGE_FALSE, false, null);
         createResource(page, PRODUCTTEASER_BADGE_TRUE_NO_AGE, true, null);
         createResource(page, PRODUCTTEASER_BADGE_TRUE_WITH_AGE, true, 3);
+        createLowStockResource(page, PRODUCTTEASER_LOW_STOCK_DISABLED, false, 5, null);
+        createLowStockResource(page, PRODUCTTEASER_LOW_STOCK_IN_STOCK, true, 5, null);
+        createLowStockResource(page, PRODUCTTEASER_LOW_STOCK_CUSTOM_TEXT, true, 5, "Hurry, almost gone!");
 
         context.addModelsForClasses(MyProductTeaserImpl.class);
+    }
+
+    void createLowStockResource(Page page, String name, boolean enabled, int threshold, String customText) {
+        Map<String, Object> props = new HashMap<>();
+        props.put("sling:resourceType", "venia/components/commerce/productteaser");
+        props.put("sling:resourceSuperType", "core/cif/components/commerce/productteaser/v1/productteaser");
+        props.put("lowStockEnabled", enabled);
+        props.put("lowStockThreshold", threshold);
+        if (customText != null) {
+            props.put("lowStockText", customText);
+        }
+        props.put("linkTarget", "_blank");
+        context.create().resource(page, name, props);
     }
 
     void createResource(Page page, String name, Object badge, Object age) {
@@ -290,5 +310,69 @@ class MyProductTeaserImplTest {
     void testGetProductRetriever() throws Exception {
         setup(PRODUCTTEASER_NO_BADGE);
         Assertions.assertNotNull(underTest.getProductRetriever());
+    }
+
+    // ---- Low Stock Badge Tests ----
+
+    @Test
+    void testIsLowStock_false_featureDisabled() throws Exception {
+        setup(PRODUCTTEASER_LOW_STOCK_DISABLED);
+        Mockito.when(product.getStockStatus()).thenReturn(ProductStockStatus.IN_STOCK);
+        Mockito.when(product.getOnlyXLeftInStock()).thenReturn(3.0);
+        Assertions.assertFalse(underTest.isLowStock());
+    }
+
+    @Test
+    void testIsLowStock_false_outOfStock() throws Exception {
+        setup(PRODUCTTEASER_LOW_STOCK_IN_STOCK);
+        Mockito.when(product.getStockStatus()).thenReturn(ProductStockStatus.OUT_OF_STOCK);
+        Mockito.when(product.getOnlyXLeftInStock()).thenReturn(3.0);
+        Assertions.assertFalse(underTest.isLowStock());
+    }
+
+    @Test
+    void testIsLowStock_false_nullOnlyXLeft() throws Exception {
+        setup(PRODUCTTEASER_LOW_STOCK_IN_STOCK);
+        Mockito.when(product.getStockStatus()).thenReturn(ProductStockStatus.IN_STOCK);
+        Mockito.when(product.getOnlyXLeftInStock()).thenReturn(null);
+        Assertions.assertFalse(underTest.isLowStock());
+    }
+
+    @Test
+    void testIsLowStock_false_aboveThreshold() throws Exception {
+        setup(PRODUCTTEASER_LOW_STOCK_IN_STOCK);
+        Mockito.when(product.getStockStatus()).thenReturn(ProductStockStatus.IN_STOCK);
+        Mockito.when(product.getOnlyXLeftInStock()).thenReturn(10.0); // threshold is 5
+        Assertions.assertFalse(underTest.isLowStock());
+    }
+
+    @Test
+    void testIsLowStock_true() throws Exception {
+        setup(PRODUCTTEASER_LOW_STOCK_IN_STOCK);
+        Mockito.when(product.getStockStatus()).thenReturn(ProductStockStatus.IN_STOCK);
+        Mockito.when(product.getOnlyXLeftInStock()).thenReturn(3.0); // threshold is 5
+        Assertions.assertTrue(underTest.isLowStock());
+    }
+
+    @Test
+    void testGetLowStockMessage_auto() throws Exception {
+        setup(PRODUCTTEASER_LOW_STOCK_IN_STOCK);
+        Mockito.when(product.getStockStatus()).thenReturn(ProductStockStatus.IN_STOCK);
+        Mockito.when(product.getOnlyXLeftInStock()).thenReturn(3.0);
+        Assertions.assertEquals("Only 3 left!", underTest.getLowStockMessage());
+    }
+
+    @Test
+    void testGetLowStockMessage_customText() throws Exception {
+        setup(PRODUCTTEASER_LOW_STOCK_CUSTOM_TEXT);
+        Mockito.when(product.getStockStatus()).thenReturn(ProductStockStatus.IN_STOCK);
+        Mockito.when(product.getOnlyXLeftInStock()).thenReturn(2.0);
+        Assertions.assertEquals("Hurry, almost gone!", underTest.getLowStockMessage());
+    }
+
+    @Test
+    void testGetLowStockMessage_null_whenNotLowStock() throws Exception {
+        setup(PRODUCTTEASER_LOW_STOCK_DISABLED);
+        Assertions.assertNull(underTest.getLowStockMessage());
     }
 }

--- a/docs/low-stock-badge.md
+++ b/docs/low-stock-badge.md
@@ -1,0 +1,98 @@
+# Low Stock Badge — Custom Product Teaser Extension
+
+A real-world AEM CIF customisation demonstrating how to extend the out-of-the-box
+`ProductTeaser` component to surface live Magento inventory data in the AEM authoring
+experience and on the published storefront.
+
+## What it does
+
+When a product's **only_x_left_in_stock** quantity is at or below a configurable
+threshold and the product is still `IN_STOCK`, a red pill badge is rendered
+bottom-left on the product teaser:
+
+```
+┌────────────────────────┐
+│                        │
+│   [product image]      │
+│                        │
+│ ┌──────────────┐       │
+│ │ ONLY 3 LEFT! │       │
+│ └──────────────┘       │
+└────────────────────────┘
+```
+
+The badge is fully author-configurable per component instance.
+
+## Architecture
+
+This follows the standard AEM CIF extension pattern:
+
+```
+MyProductTeaser (interface)
+    └── extends ProductTeaser (CIF Core)
+            └── MyProductTeaserImpl (Sling Model)
+                    └── delegates to ProductTeaser via @Via(ResourceSuperType)
+                    └── extends GraphQL query with stockStatus + onlyXLeftInStock
+```
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `core/.../MyProductTeaser.java` | Added `isLowStock()` and `getLowStockMessage()` to interface |
+| `core/.../MyProductTeaserImpl.java` | Implemented both methods; extended GraphQL query |
+| `core/.../MyProductTeaserImplTest.java` | 8 new unit tests covering all branches |
+| `ui.apps/.../productteaser.html` | Added conditional low stock badge `<div>` |
+| `ui.apps/.../_cq_dialog/.content.xml` | Added "Low Stock Badge" author dialog tab |
+| `ui.frontend/.../\_productteaser.scss` | Added `.item__badge--low-stock` pill style |
+
+## Author dialog
+
+The component dialog gains a new **Low Stock Badge** tab with three fields:
+
+| Field | Property | Default | Description |
+|-------|----------|---------|-------------|
+| Enable checkbox | `lowStockEnabled` | `false` | Opt-in per component instance |
+| Low Stock Threshold | `lowStockThreshold` | `5` | Show badge when qty ≤ this value |
+| Badge Text | `lowStockText` | *(empty)* | Custom text; leave empty for "Only N left!" |
+
+## Magento requirements
+
+- Magento 2.4+ with **Only X Left in Stock** enabled:
+  `Stores > Configuration > Catalog > Inventory > Only X left Threshold`
+- Products must have `only_x_left_in_stock` populated (Magento sets this
+  automatically when stock drops below the configured threshold).
+
+## GraphQL query extension
+
+The implementation appends two fields to the CIF-generated product query:
+
+```graphql
+stock_status
+only_x_left_in_stock
+```
+
+via `AbstractProductRetriever.extendProductQueryWith()`. The CIF framework chains
+all registered consumers and executes a single optimised query.
+
+## Building and deploying
+
+```bash
+# Run unit tests only
+mvn test -pl core
+
+# Full build + deploy to local AEM SDK (author on :4502)
+export JAVA_HOME=/opt/homebrew/opt/openjdk@21
+mvn clean install -PautoInstallSinglePackage -Dclassic \
+    -Daem.host=localhost -Daem.port=4502
+```
+
+## Testing the badge
+
+1. In your Magento admin, go to **Catalog > Products** and edit a product.
+2. Set **Quantity** to e.g. 3 and ensure **Manage Stock** is enabled.
+3. In `Stores > Configuration > Catalog > Inventory`, set **Only X left Threshold** to `5`.
+4. In AEM, add a **Product Teaser** component to a page and pick that product.
+5. Open the component dialog > **Low Stock Badge** tab.
+6. Check **Enable 'Low Stock' badge** and save.
+7. Preview or publish the page — the badge should appear.

--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/productteaser/_cq_dialog/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/productteaser/_cq_dialog/.content.xml
@@ -57,6 +57,48 @@
                             </columns>
                         </items>
                     </badge>
+                    <lowstock jcr:primaryType="nt:unstructured"
+                        jcr:title="Low Stock Badge"
+                        sling:resourceType="granite/ui/components/coral/foundation/container"
+                        margin="{Boolean}true">
+                        <items jcr:primaryType="nt:unstructured">
+                            <columns jcr:primaryType="nt:unstructured"
+                                sling:resourceType="granite/ui/components/coral/foundation/fixedcolumns"
+                                margin="{Boolean}true">
+                                <items jcr:primaryType="nt:unstructured">
+                                    <column jcr:primaryType="nt:unstructured"
+                                        sling:resourceType="granite/ui/components/coral/foundation/container">
+                                        <items jcr:primaryType="nt:unstructured">
+                                            <lowStockEnabled jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/checkbox"
+                                                text="Enable 'Low Stock' badge"
+                                                value="true"
+                                                uncheckedValue="false"
+                                                name="./lowStockEnabled" />
+                                            <lowStockThreshold jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/numberfield"
+                                                fieldLabel="Low Stock Threshold"
+                                                fieldDescription="Show badge when remaining quantity is at or below this number"
+                                                name="./lowStockThreshold"
+                                                min="{Long}1"
+                                                value="5" />
+                                            <lowStockThresholdTypeHint jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/foundation/form/hidden"
+                                                ignoreData="{Boolean}true"
+                                                name="./lowStockThreshold@TypeHint"
+                                                value="Long" />
+                                            <lowStockText jcr:primaryType="nt:unstructured"
+                                                sling:resourceType="granite/ui/components/coral/foundation/form/textfield"
+                                                fieldLabel="Badge Text"
+                                                fieldDescription="Leave empty to auto-generate 'Only N left!'"
+                                                name="./lowStockText"
+                                                emptyText="Only N left!" />
+                                        </items>
+                                    </column>
+                                </items>
+                            </columns>
+                        </items>
+                    </lowstock>
                 </items>
             </tabs>
         </items>

--- a/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/productteaser/productteaser.html
+++ b/ui.apps/src/main/content/jcr_root/apps/venia/components/commerce/productteaser/productteaser.html
@@ -32,6 +32,9 @@
         <div data-sly-test="${product.showBadge}" class="item__badge">
             <span>${properties.text || 'New'}</span>
         </div>
+        <div data-sly-test="${product.lowStock}" class="item__badge item__badge--low-stock">
+            <span>${product.lowStockMessage}</span>
+        </div>
 
         <sly data-sly-call="${imageTpl.actions @ product=product}" />
 

--- a/ui.frontend/src/main/styles/commerce/_productteaser.scss
+++ b/ui.frontend/src/main/styles/commerce/_productteaser.scss
@@ -95,6 +95,37 @@
         }
     }
 
+    .item__badge--low-stock {
+        position: absolute;
+        bottom: 8px;
+        left: 8px;
+        width: auto;
+        height: auto;
+        overflow: visible;
+        background: transparent;
+
+        &:before,
+        &:after {
+            display: none;
+        }
+
+        span {
+            position: static;
+            display: inline-block;
+            width: auto;
+            padding: 4px 10px;
+            background-color: #e03131;
+            border-radius: 12px;
+            color: #fff;
+            font: 700 12px/1 "Lato", sans-serif;
+            text-transform: uppercase;
+            text-align: center;
+            transform: none;
+            box-shadow: 0 2px 6px rgba(0, 0, 0, 0.25);
+            letter-spacing: 0.05em;
+        }
+    }
+
     .productteaser__cta {
         position: relative;
         text-align: center;


### PR DESCRIPTION
## Summary

Extends the Venia `MyProductTeaser` scaffolding with a **Low Stock Badge** — a real-world CIF customisation that surfaces live Magento inventory data directly in the AEM authoring experience and on the published storefront.

- Adds `isLowStock()` / `getLowStockMessage()` to `MyProductTeaser` interface and implements them in `MyProductTeaserImpl`, extending the CIF GraphQL query with `stock_status` and `only_x_left_in_stock`
- Adds a **Low Stock Badge** author dialog tab with enable toggle, threshold number field, and optional custom text
- Renders a red pill badge bottom-left on the product image when stock is at or below threshold
- Ships with 8 new unit tests; 49 total passing

## What it looks like

```
┌────────────────────────┐
│                        │
│   [product image]      │
│                        │
│ ┌──────────────┐       │
│ │ ONLY 3 LEFT! │       │
│ └──────────────┘       │
└────────────────────────┘
```

## Files changed

| File | Change |
|------|--------|
| `core/.../MyProductTeaser.java` | Added `isLowStock()` and `getLowStockMessage()` |
| `core/.../MyProductTeaserImpl.java` | Implementation + GraphQL extension |
| `core/.../MyProductTeaserImplTest.java` | 8 new tests (49 total, 0 failures) |
| `ui.apps/.../productteaser.html` | Conditional badge div |
| `ui.apps/.../_cq_dialog/.content.xml` | "Low Stock Badge" author tab |
| `ui.frontend/.../_productteaser.scss` | `.item__badge--low-stock` pill style |
| `docs/low-stock-badge.md` | Full implementation guide |

## Test plan

- [ ] `mvn test -pl core` passes (49 tests, 0 failures) with `JAVA_HOME` pointed at Java 21
- [ ] Full build: `mvn clean install -PautoInstallSinglePackage -Dclassic`
- [ ] Open Product Teaser dialog → Low Stock Badge tab visible
- [ ] Enable badge on a product with `only_x_left_in_stock ≤ threshold` → badge renders
- [ ] Custom text field overrides auto "Only N left!" message
- [ ] Disabled or out-of-stock product → no badge rendered

## Requirements

- Magento 2.4+ with **Only X Left in Stock** enabled (`Stores > Configuration > Catalog > Inventory`)
- AEM CIF Core Components

🤖 Generated with [Claude Code](https://claude.com/claude-code)