### PR TITLE
SITES-42447 - AI rules and skills for CIF repositories

### DIFF
--- a/.circleci/ci/deploy-venia.js
+++ b/.circleci/ci/deploy-venia.js
@@ -35,7 +35,7 @@ ci.sh("mkdir -p artifacts");
 
 ci.stage("Deploy Venia Sample Project to Maven Central");
 // build and deploy only the cloud artifacts
-ci.sh(`mvn ${mvnOpts} clean deploy -Prelease,ossrh`)
+ci.sh(`mvn ${mvnOpts} clean deploy -Prelease,central`)
 ci.sh(`cp all/target/${releaseArtifact}.all-${releaseVersion}.zip artifacts/${releaseArtifact}.all-${releaseVersion}.zip`);
 
 ci.stage("Deploy Venia Sample Project to GitHub");

--- a/.circleci/settings.xml
+++ b/.circleci/settings.xml
@@ -68,7 +68,7 @@
         </profile>
 
         <profile>
-            <id>ossrh</id>
+            <id>central</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
@@ -81,9 +81,9 @@
 
     <servers>
         <server>
-            <id>ossrh</id>
-            <username>${env.SONATYPE_USER}</username>
-            <password>${env.SONATYPE_PASS}</password>
+            <id>central</id>
+            <username>${env.MAVEN_CENTRAL_USERNAME}</username>
+            <password>${env.MAVEN_CENTRAL_PASSWORD}</password>
         </server>
         <server>
             <id>maven-adobe-cif-release</id>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,56 @@
+# Venia CIF Reference Storefront
+
+AEM CIF reference storefront for AEM as a Cloud Service with React frontend.
+
+## Build
+
+JDK 11, Maven 3.3.9+. Node 12.14.1 / npm 6.14.6 auto-installed by frontend-maven-plugin.
+
+- `mvn clean install` -- full build (all modules)
+- `mvn clean install -pl core` -- build only the core OSGi bundle
+- `mvn clean install -pl ui.frontend` -- build only the frontend (runs webpack prod)
+- `mvn clean install -PautoInstallSinglePackage` -- build and deploy the `all` package to a local AEM instance
+- `mvn clean install -pl core -PautoInstallBundle` -- build and deploy the core bundle only
+- `mvn clean install -Pclassic` -- include classic (AEM 6.5) modules
+
+## Testing
+
+- **Java unit** (JUnit 5, Mockito, AEM Mocks): `mvn test -pl core` -- JaCoCo enforces 50% branch coverage
+- **Frontend unit** (Jest, React Testing Library): `cd ui.frontend && npm test` -- includes lint + prettier check
+- **Integration** (JUnit 4, AEM Cloud Testing Clients): `mvn verify -pl it.tests -Plocal` -- requires running AEM author + publish
+- **UI E2E** (WebdriverIO): `mvn verify -pl ui.tests -Pui-tests-local-execution` -- requires running AEM
+
+## Code Style
+
+### Java
+- Apache License 2.0 header required on all source files
+- No enforced formatter -- follow existing code conventions
+
+### Frontend (ui.frontend)
+- ESLint: `npm run lint` / `npm run lint:fix` -- enforces Apache license header via `eslint-plugin-header`
+- Prettier: `npm run prettier:check` / `npm run prettier:fix` -- 120 char width, 4-space indent, single quotes
+- Both run automatically as part of `npm test`
+
+## Module Map
+
+| Module | Path | Description |
+|--------|------|-------------|
+| core | `core/` | OSGi bundle -- Sling Models, servlets, services |
+| ui.frontend | `ui.frontend/` | React/Webpack frontend -- CIF storefront components, clientlibs |
+| ui.apps | `ui.apps/` | AEM content package -- HTL components, clientlib nodes, component dialogs |
+| ui.apps.structure | `ui.apps.structure/` | Repository structure package defining /apps roots |
+| ui.config | `ui.config/` | OSGi configurations for AEM as a Cloud Service |
+| ui.content | `ui.content/` | Mutable content -- page templates, policies, sample pages |
+| all | `all/` | Container package embedding all modules + CIF Core Components |
+| it.tests | `it.tests/` | Server-side integration tests (Cloud Manager compatible) |
+| ui.tests | `ui.tests/` | Selenium/WebdriverIO UI end-to-end tests |
+| dispatcher | `dispatcher/` | AEM Dispatcher configuration (Cloud Service) |
+| classic/* | `classic/` | AEM 6.5 Classic variants (activated with `-Pclassic`) |
+
+## Architecture
+
+- **Backend**: Sling Models under `com.venia.core.models` extending CIF Core Component models. OSGi + BND for bundle metadata.
+- **Frontend**: React 17 + Webpack 4. Extends `@adobe/aem-core-cif-react-components` with custom components/talons. Output packaged as AEM clientlibs via `aem-clientlib-generator`.
+- **Commerce**: GraphQL to Adobe Commerce via CIF GraphQL client (`magento-graphql` bindings). Apollo Client on frontend.
+- **AEM Components**: HTL templates in `ui.apps` delegate to Sling Models. Proxy pattern extending CIF Core and WCM Core components under `venia/components/`.
+- **Deployment**: AEM as a Cloud Service (primary), AEM 6.5 (classic profile). `aemanalyser-maven-plugin` validates Cloud Service compatibility.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,12 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-releases/</url>
         </repository>
     </distributionManagement>
 
@@ -157,10 +157,10 @@
                     <target>11</target>
                 </configuration>
             </plugin>
-            <!-- Sonatype staging plugin -->
+            <!-- Sonatype Central publishing plugin -->
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
             </plugin>
         </plugins>
         <pluginManagement>
@@ -425,16 +425,15 @@ Bundle-DocURL:
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
-                <!-- Sonatype staging plugin -->
+                <!-- Sonatype Central publishing plugin  -->
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.7</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.9.0</version>
                     <extensions>true</extensions>
                     <configuration>
-                        <serverId>ossrh</serverId>
-                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        <publishingServerId>central</publishingServerId>
+                        <autoPublish>true</autoPublish>
                     </configuration>
                 </plugin>
             </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
         <core.wcm.components.version>2.29.0</core.wcm.components.version>
-        <core.cif.components.version>2.18.0</core.cif.components.version>
+        <core.cif.components.version>2.18.2</core.cif.components.version>
         <graphql.client.version>1.10.0</graphql.client.version>
         <magento.graphql.version>9.1.0-magento242ee</magento.graphql.version>
         <bnd.version>5.1.2</bnd.version>

--- a/ui.frontend/package-lock.json
+++ b/ui.frontend/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@adobe/aem-core-cif-product-recs-extension": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@adobe/aem-core-cif-product-recs-extension/-/aem-core-cif-product-recs-extension-2.18.0.tgz",
-      "integrity": "sha512-fTU+nxGp4UfXI/+AhPB470GeyRbLwHbRLf8pFgh6KebgwCYdfKHv9JS5OMq70+GguFlCyhbjjBo1JtGy9+bDzw=="
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@adobe/aem-core-cif-product-recs-extension/-/aem-core-cif-product-recs-extension-2.18.2.tgz",
+      "integrity": "sha512-KukjgGsBQsDKwRTf9hMdvctTlrattVNzUCulAcYAR5z3AmEIcdSukY1aaUK5pG5ce6DdjYwZI8vDmUvcI4SmfA=="
     },
     "@adobe/aem-core-cif-react-components": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/@adobe/aem-core-cif-react-components/-/aem-core-cif-react-components-2.18.0.tgz",
-      "integrity": "sha512-Nxyo3fuTFtgtOuKql6eB37fWNxySvBNBxTNQQpli00yjOGO7WLXABqIxql17oVVz+flMP7oG4JCPVD+OpbL8wA=="
+      "version": "2.18.2",
+      "resolved": "https://registry.npmjs.org/@adobe/aem-core-cif-react-components/-/aem-core-cif-react-components-2.18.2.tgz",
+      "integrity": "sha512-84vbF5Xe38MnA9cDwaF3gHugOmh1fivYuLoHH4jX7rWvrwX9q976aKTi5iKI2qr3rxcQ4s/EszksrPlEIu0d9w=="
     },
     "@apollo/client": {
       "version": "3.5.6",

--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -87,8 +87,8 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@adobe/aem-core-cif-product-recs-extension": "^2.18.0",
-    "@adobe/aem-core-cif-react-components": "^2.18.0",
+    "@adobe/aem-core-cif-product-recs-extension": "^2.18.2",
+    "@adobe/aem-core-cif-react-components": "^2.18.2",
     "@apollo/client": "^3.5.5",
     "@babel/runtime": "^7.4.5",
     "@magento/peregrine": "11.0.0",


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` with build, test, code style, module map, and architecture documentation for AI coding assistants
- Add `CLAUDE.md` referencing AGENTS.md for Claude Code integration

> **Note:** This branch also includes changes from prior commits (OSSRH → Central Portal migration, CIF Components 2.18.2 bump) that were already merged to main via separate PRs. The only net-new change in this PR is the AI rules files.

## Test plan
- [ ] Verify `AGENTS.md` renders correctly on GitHub
- [ ] Verify Claude Code picks up `CLAUDE.md` and `AGENTS.md` when working in this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)