### PR TITLE
SITES-45016 - Release CIF components 2.18.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <vault.user>admin</vault.user>
         <vault.password>admin</vault.password>
         <core.wcm.components.version>2.29.0</core.wcm.components.version>
-        <core.cif.components.version>2.18.2</core.cif.components.version>
+        <core.cif.components.version>2.18.4</core.cif.components.version>
         <graphql.client.version>1.10.0</graphql.client.version>
         <magento.graphql.version>9.1.0-magento242ee</magento.graphql.version>
         <bnd.version>5.1.2</bnd.version>

--- a/ui.frontend/package-lock.json
+++ b/ui.frontend/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@adobe/aem-core-cif-product-recs-extension": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/@adobe/aem-core-cif-product-recs-extension/-/aem-core-cif-product-recs-extension-2.18.2.tgz",
-      "integrity": "sha512-KukjgGsBQsDKwRTf9hMdvctTlrattVNzUCulAcYAR5z3AmEIcdSukY1aaUK5pG5ce6DdjYwZI8vDmUvcI4SmfA=="
+      "version": "2.18.4",
+      "resolved": "https://registry.npmjs.org/@adobe/aem-core-cif-product-recs-extension/-/aem-core-cif-product-recs-extension-2.18.4.tgz",
+      "integrity": "sha512-IYWfhtNnAZSm88LdhGUbWPgT3LALh8jnEFrisR3jVeVoTLr7b6qe0GJ1vA73XJWtegsujBzmSaz0fD1nExibOw=="
     },
     "@adobe/aem-core-cif-react-components": {
-      "version": "2.18.2",
-      "resolved": "https://registry.npmjs.org/@adobe/aem-core-cif-react-components/-/aem-core-cif-react-components-2.18.2.tgz",
-      "integrity": "sha512-84vbF5Xe38MnA9cDwaF3gHugOmh1fivYuLoHH4jX7rWvrwX9q976aKTi5iKI2qr3rxcQ4s/EszksrPlEIu0d9w=="
+      "version": "2.18.4",
+      "resolved": "https://registry.npmjs.org/@adobe/aem-core-cif-react-components/-/aem-core-cif-react-components-2.18.4.tgz",
+      "integrity": "sha512-Yz586U886OJ6x53m6wfsjR7iHcPg++1gDAL8JMs8DfKvvtcpgBkmdT4/DBxEq62ce6xxQvC+tFLv4oMrMotd4w=="
     },
     "@apollo/client": {
       "version": "3.5.6",

--- a/ui.frontend/package.json
+++ b/ui.frontend/package.json
@@ -87,8 +87,8 @@
     "webpack-merge": "^4.2.1"
   },
   "dependencies": {
-    "@adobe/aem-core-cif-product-recs-extension": "^2.18.2",
-    "@adobe/aem-core-cif-react-components": "^2.18.2",
+    "@adobe/aem-core-cif-product-recs-extension": "^2.18.4",
+    "@adobe/aem-core-cif-react-components": "^2.18.4",
     "@apollo/client": "^3.5.5",
     "@babel/runtime": "^7.4.5",
     "@magento/peregrine": "11.0.0",


### PR DESCRIPTION
## Description

Bump the AEM CIF Core Components dependency in the Venia reference storefront to **2.18.4**.

* `pom.xml`: `core.cif.components.version` 2.18.2 → 2.18.4
* `ui.frontend/package.json`: `@adobe/aem-core-cif-react-components` and `@adobe/aem-core-cif-product-recs-extension` ^2.18.2 → ^2.18.4
* `ui.frontend/package-lock.json`: refreshed with the 2.18.4 tarballs and integrity hashes

## Related Issue

SITES-45016

## Verification

`2.18.4` artifacts have been verified on Maven Central and npmjs.


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author